### PR TITLE
README.rst: Change pycon to code-block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ The Pitch
 
 ``structlog`` makes structured logging with *incremental context building* and *arbitrary formatting* as easy as:
 
-.. pycon::
+.. code-block:: pycon
 
    >>> from structlog import get_logger
    >>> log = get_logger()


### PR DESCRIPTION
I think it wasn't rendering because the `pycon` is not a know reST directive.

With this hopefully, it will show up without highlighting and then with highlighting when GitHub pushes out their change. It should be highlighted on PyPI today if you register the new description.

Preview at https://github.com/msabramo/structlog/blob/patch-1/README.rst