### PR TITLE
Add exception among supported levels in stdlib

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ The following folks helped forming ``structlog`` into what it is now:
 - `Jean-Paul Calderone <http://as.ynchrono.us>`_
 - `Lakshmi Kannan <https://github.com/lakshmi-kannan>`_
 - `Lynn Root <https://github.com/econchick>`_
+- `Mathieu Leplatre <https://github.com/leplatrem>`_
 - `Noah Kantrowitz <https://github.com/coderanger>`_
 - `Tarek Ziadé <https://github.com/tarekziade>`_
 - `Thomas Heinrichsdobler <https://github.com/dertyp>`_

--- a/structlog/stdlib.py
+++ b/structlog/stdlib.py
@@ -289,6 +289,7 @@ NOTSET = 0
 
 _NAME_TO_LEVEL = {
     'critical': CRITICAL,
+    'exception': ERROR,
     'error': ERROR,
     'warn': WARNING,
     'warning': WARNING,

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -132,6 +132,7 @@ class TestFilterByLevel(object):
         event_dict = {'event': 'test'}
         assert event_dict is filter_by_level(logger, 'warn', event_dict)
         assert event_dict is filter_by_level(logger, 'error', event_dict)
+        assert event_dict is filter_by_level(logger, 'exception', event_dict)
 
 
 class TestBoundLogger(object):


### PR DESCRIPTION
Using ``logger.exception(e)`` failed with processor ``structlog.stdlib.filter_by_level``