### PR TITLE
Add option to specify key in TimeStamper processor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+- :release:`15.2.0 <unreleased>`
+- :feature:`51` Add option to specify target key in :class:`structlog.processor.TimeStamper` processor.
 - :release:`15.1.0 <2015-02-24>`
 - :bug:`- major` Tolerate frames without a ``__name__``.
 - :release:`15.0.0 <2015-01-23>`

--- a/structlog/processors.py
+++ b/structlog/processors.py
@@ -207,7 +207,7 @@ class TimeStamper(object):
         <http://en.wikipedia.org/wiki/ISO_8601>`_, or `None` for a `UNIX
         timestamp <http://en.wikipedia.org/wiki/Unix_time>`_.
     :param bool utc: Whether timestamp should be in UTC or local time.
-    :param str key: Property name stored in `event_dict`.
+    :param str key: Target key in `event_dict` for added timestamps.
 
     >>> from structlog.processors import TimeStamper
     >>> TimeStamper()(None, None, {})  # doctest: +SKIP

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -136,6 +136,9 @@ class TestTimeStamper(object):
 
     @freeze_time('1980-03-25 16:00:00')
     def test_key_can_be_specified(self):
+        """
+        Timestamp is stored with the specified key.
+        """
         ts = TimeStamper(fmt='%m', key='month')
         d = ts(None, None, {})
         assert '03' == d['month']

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -134,6 +134,12 @@ class TestTimeStamper(object):
         d = ts(None, None, {})
         assert '1980-03-25T16:00:00Z' == d['timestamp']
 
+    @freeze_time('1980-03-25 16:00:00')
+    def test_key_can_be_specified(self):
+        ts = TimeStamper(fmt='%m', key='month')
+        d = ts(None, None, {})
+        assert '03' == d['month']
+
 
 class TestFormatExcInfo(object):
     def test_formats_tuple(self, monkeypatch):


### PR DESCRIPTION
In my environment, the logging standard is to store the human-readable timestamp in a ``'time'`` entry :)