### PR TITLE
Better support for missing __name__ in frame traversal

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ The following folks helped forming ``structlog`` into what it is now:
 - `Itamar Turner-Trauring <https://github.com/itamarst>`_
 - `Jack Pearkes <https://github.com/pearkes>`_
 - `Jean-Paul Calderone <http://as.ynchrono.us>`_
+- `Justin Wood (Callek) <https://github.com/Callek>`_
 - `Lakshmi Kannan <https://github.com/lakshmi-kannan>`_
 - `Lynn Root <https://github.com/econchick>`_
 - `Mathieu Leplatre <https://github.com/leplatrem>`_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+- :bug:`- major` Tolerate frames without a ``__name__``, better.
 - :feature:`-` Add :func:`structlog.ReturnLogger.failure` and :func:`structlog.PrintLogger.failure` as preparation for the new Twisted logging system.
 - :release:`15.2.0 <2015-06-10>`
 - :bug:`- major` Allow empty lists of processors.

--- a/structlog/_frames.py
+++ b/structlog/_frames.py
@@ -37,7 +37,7 @@ def _find_first_app_frame_and_name(additional_ignores=None):
     """
     ignores = ["structlog"] + (additional_ignores or [])
     f = sys._getframe()
-    name = f.f_globals.get("__name__", "?")
+    name = f.f_globals.get("__name__") or "?"
     while any(name.startswith(i) for i in ignores):
         f = f.f_back
         name = f.f_globals.get("__name__") or "?"

--- a/structlog/_frames.py
+++ b/structlog/_frames.py
@@ -40,7 +40,7 @@ def _find_first_app_frame_and_name(additional_ignores=None):
     name = f.f_globals.get("__name__", "?")
     while any(name.startswith(i) for i in ignores):
         f = f.f_back
-        name = f.f_globals.get("__name__", "?")
+        name = f.f_globals.get("__name__") or "?"
     return f, name
 
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -28,7 +28,7 @@ class TestFindFirstAppFrameAndName(object):
         f2 = stub(f_globals={'__name__': 'structlog.blubb'}, f_back=f1)
         monkeypatch.setattr(structlog._frames.sys, '_getframe', lambda: f2)
         f, n = _find_first_app_frame_and_name()
-        assert ((f1, 'test') == f, n)
+        assert ((f1, 'test') == (f, n))
 
     def test_ignoring_of_additional_frame_names_works(self, monkeypatch):
         """
@@ -38,17 +38,36 @@ class TestFindFirstAppFrameAndName(object):
         f2 = stub(f_globals={'__name__': 'ignored.bar'}, f_back=f1)
         f3 = stub(f_globals={'__name__': 'structlog.blubb'}, f_back=f2)
         monkeypatch.setattr(structlog._frames.sys, '_getframe', lambda: f3)
-        f, n = _find_first_app_frame_and_name()
-        assert ((f1, 'test') == f, n)
+        f, n = _find_first_app_frame_and_name(additional_ignores=['ignored'])
+        assert ((f1, 'test') == (f, n))
 
     def test_tolerates_missing_name(self, monkeypatch):
         """
         Use ``?`` if `f_globals` lacks a `__name__` key
         """
         f1 = stub(f_globals={}, f_back=None)
-        f, n = _find_first_app_frame_and_name()
         monkeypatch.setattr(structlog._frames.sys, "_getframe", lambda: f1)
-        assert ((f1, "?") == f, n)
+        f, n = _find_first_app_frame_and_name()
+        assert ((f1, "?") == (f, n))
+
+    def test_tolerates_missing_names_explicitly_None_oneframe(self, monkeypatch):
+        """
+        Use ``?`` if `f_globals` has a `None` valued `__name__` key
+        """
+        f1 = stub(f_globals={'__name__': None}, f_back=None)
+        monkeypatch.setattr(structlog._frames.sys, "_getframe", lambda: f1)
+        f, n = _find_first_app_frame_and_name()
+        assert ((f1, "?") == (f, n))
+
+    def test_tolerates_missing_names_explicitly_None_manyframe(self, monkeypatch):
+        """
+        Use ``?`` if `f_globals` has a `None` valued `__name__` key, multiple frames up.
+        """
+        f1 = stub(f_globals={'__name__': None}, f_back=None)
+        f2 = stub(f_globals={'__name__': 'structlog.blubb'}, f_back=f1)
+        monkeypatch.setattr(structlog._frames.sys, "_getframe", lambda: f2)
+        f, n = _find_first_app_frame_and_name()
+        assert ((f1, "?") == (f, n))
 
 
 @pytest.fixture

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -61,7 +61,8 @@ class TestFindFirstAppFrameAndName(object):
 
     def test_tolerates_name_explicitly_None_manyframe(self, monkeypatch):
         """
-        Use ``?`` if `f_globals` has a `None` valued `__name__` key, multiple frames up.
+        Use ``?`` if `f_globals` has a `None` valued `__name__` key,
+        multiple frames up.
         """
         f1 = stub(f_globals={'__name__': None}, f_back=None)
         f2 = stub(f_globals={'__name__': 'structlog.blubb'}, f_back=f1)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -50,7 +50,7 @@ class TestFindFirstAppFrameAndName(object):
         f, n = _find_first_app_frame_and_name()
         assert ((f1, "?") == (f, n))
 
-    def test_tolerates_missing_names_explicitly_None_oneframe(self, monkeypatch):
+    def test_tolerates_name_explicitly_None_oneframe(self, monkeypatch):
         """
         Use ``?`` if `f_globals` has a `None` valued `__name__` key
         """
@@ -59,7 +59,7 @@ class TestFindFirstAppFrameAndName(object):
         f, n = _find_first_app_frame_and_name()
         assert ((f1, "?") == (f, n))
 
-    def test_tolerates_missing_names_explicitly_None_manyframe(self, monkeypatch):
+    def test_tolerates_name_explicitly_None_manyframe(self, monkeypatch):
         """
         Use ``?`` if `f_globals` has a `None` valued `__name__` key, multiple frames up.
         """


### PR DESCRIPTION
In my own code, I got a new traceback for this issue (meant to be fixed in release of 15.1.0)

With some DEBUG prints sprinkled in, I was able to see that ``f.f_frame.has_key("__name__")`` was ``True``, however ``f.f_frame.get("__name__", "?")`` would still return ``None`` thus skipping that default choice.

Per python docs, ``foo.get("whatever")`` already has a default value of ``None`` so simply mixing them with "or" will achieve the desired goal here in all existing cases, as well as fix my own case.

For reference the full traceback I had:
```
Traceback (most recent call last):
  File "/data/www/relengapi/celery", line 81, in <module>
    load_entry_point('celery', 'console_scripts', 'celery')()
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/__main__.py", line 30, in main
    main()
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/celery.py", line 81, in main
    cmd.execute_from_commandline(argv)
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/celery.py", line 769, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/base.py", line 307, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/celery.py", line 761, in handle_argv
    return self.execute(command, argv)
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/celery.py", line 693, in execute
    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/worker.py", line 179, in run_from_argv
    return self(*args, **options)
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/base.py", line 270, in __call__
    ret = self.run(*args, **kwargs)
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bin/worker.py", line 212, in run
    state_db=self.node_format(state_db, hostname), **kwargs
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/worker/__init__.py", line 100, in __init__
    self.setup_instance(**self.prepare_args(**kwargs))
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/worker/__init__.py", line 141, in setup_instance
    self.blueprint.apply(self, **kwargs)
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bootsteps.py", line 209, in apply
    self._debug('Preparing bootsteps.')
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/celery/bootsteps.py", line 272, in _debug
    return debug(_pre(self, msg), *args)
  File "/usr/lib/python2.7/logging/__init__.py", line 1128, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/data/www/relengapi/celery", line 62, in new_log
    old_log(self, level, msg, args, exc_info=None, extra=extra)
  File "/usr/lib/python2.7/logging/__init__.py", line 1249, in _log
    fn, lno, func = self.findCaller()
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/structlog/stdlib.py", line 32, in findCaller
    f, name = _find_first_app_frame_and_name(['logging'])
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/structlog/_frames.py", line 41, in _find_first_app_frame_and_name
    while any(name.startswith(i) for i in ignores):
  File "/data/www/relengapi/virtualenv/lib/python2.7/site-packages/structlog/_frames.py", line 41, in <genexpr>
    while any(name.startswith(i) for i in ignores):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

If this patch is accepted, I would appreciate a new structlog release, sooner than later.