### PR TITLE
Fix assert-is-always-True in twisted tests

### DIFF
--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -101,12 +101,12 @@ class TestExtractStuffAndWhy(object):
         Extracts failures and events.
         """
         assert (
-            Failure(ValueError()), "foo", {} ==
+            (Failure(ValueError()), "foo", {}) ==
             _extractStuffAndWhy({"_why": "foo",
                                  "_stuff": Failure(ValueError())})
         )
         assert (
-            Failure(ValueError()), "error", {} ==
+            (Failure(ValueError()), "error", {}) ==
             _extractStuffAndWhy({"_stuff": Failure(ValueError())})
         )
 


### PR DESCRIPTION
This issue was found during my work on #58 (and is where I added myself to authors)

I don't feel this is worth adding to the changelog, and is the only place (other than #58) in which this was a problem afaict.