### PR TITLE
Adds JSON Formatter to Structlog's Stdlib Module

### DIFF
--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -71,7 +71,10 @@ To make your program behave like a proper `12 factor app`_ that outputs only JSO
     import logging
     import sys
 
+    import structlog
+
     handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(structlog.StdlibJSONFormatter())
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ["python-json-logger"]
 
 ###############################################################################
 

--- a/structlog/stdlib.py
+++ b/structlog/stdlib.py
@@ -285,10 +285,10 @@ class StdlibJSONFormatter(jsonlogger.JsonFormatter):
     Used to JSON-ify stdlib log messages in the event that you cannot
     control whether `logging.getLogger()` or `structlog.get_logger()`
     is called (like when including third party libraries).
-    """
 
-    def __init__(self, *args, **kwargs):
-        super(StdlibJSONFormatter, self).__init__(*args, **kwargs)
+    To use this, simply add this formatter to a stdlib logging's
+    handler or logger.
+    """
 
     def format(self, record):
         """
@@ -303,7 +303,7 @@ class StdlibJSONFormatter(jsonlogger.JsonFormatter):
         except ValueError:
             # If the record text is not already JSON, let the
             # JSONFormatter format it correctly.
-            return super(StdlibJSONFormatter, self).format(record)
+            return jsonlogger.JsonFormatter().format(record)
 
 # Adapted from the stdlib
 

--- a/structlog/stdlib.py
+++ b/structlog/stdlib.py
@@ -11,7 +11,10 @@ See also :doc:`structlog's standard library support <standard-library>`.
 
 from __future__ import absolute_import, division, print_function
 
+import json
 import logging
+
+from pythonjsonlogger import jsonlogger
 
 from structlog._base import BoundLoggerBase
 from structlog._compat import PY3
@@ -275,6 +278,32 @@ class PositionalArgumentsFormatter(object):
             if self.remove_positional_args:
                 del event_dict['positional_args']
         return event_dict
+
+
+class StdlibJSONFormatter(jsonlogger.JsonFormatter):
+    """
+    Used to JSON-ify stdlib log messages in the event that you cannot
+    control whether `logging.getLogger()` or `structlog.get_logger()`
+    is called (like when including third party libraries).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(StdlibJSONFormatter, self).__init__(*args, **kwargs)
+
+    def format(self, record):
+        """
+        Checks to see if the log message is already JSON formatted;
+        if it is, we won't touch the message. If it isn't JSON, we'll
+        let the JsonFormatter format for us.
+        """
+        try:
+            # If the record text is already a JSON message, return it.
+            json.loads(record.msg)
+            return record.msg
+        except ValueError:
+            # If the record text is not already JSON, let the
+            # JSONFormatter format it correctly.
+            return super(StdlibJSONFormatter, self).format(record)
 
 # Adapted from the stdlib
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     pretend
     pytest
     twisted
+    testfixtures
 
 setenv =
     PYTHONHASHSEED = 0


### PR DESCRIPTION
Sometimes when building your application you may need to use third party applications, and you cannot get them to point to `structlog.get_logger()`.  In which case, you may need to have your output as JSON.

So... bam!  I was wondering if I should be renaming `message` to `event` to better match how Structlog names things, so let me know about what you think.

Closes #9 