### PR TITLE
Protect from scenarios where all frames should be ignored

### DIFF
--- a/src/structlog/_frames.py
+++ b/src/structlog/_frames.py
@@ -39,6 +39,9 @@ def _find_first_app_frame_and_name(additional_ignores=None):
     f = sys._getframe()
     name = f.f_globals.get("__name__") or "?"
     while any(name.startswith(i) for i in ignores):
+        if f.f_back is None:
+            name = "?"
+            break
         f = f.f_back
         name = f.f_globals.get("__name__") or "?"
     return f, name

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -70,6 +70,15 @@ class TestFindFirstAppFrameAndName(object):
         f, n = _find_first_app_frame_and_name()
         assert ((f1, "?") == (f, n))
 
+    def test_tolerates_f_back_is_None(self, monkeypatch):
+        """
+        Use ``?`` if all frames are in ignored frames.
+        """
+        f1 = stub(f_globals={'__name__': 'structlog'}, f_back=None)
+        monkeypatch.setattr(structlog._frames.sys, "_getframe", lambda: f1)
+        f, n = _find_first_app_frame_and_name()
+        assert ((f1, "?") == (f, n))
+
 
 @pytest.fixture
 def exc_info():


### PR DESCRIPTION
I ran into this scenario running the tests for my app. It opens some connections to a cassandra cluster, runs some tests, and (sometimes) doesn't close the connection. Each cluster registers an `atexit` function which closes the connection. 

When `py.test` runs these tests, just before quitting it prints the following traceback:

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "cassandra/cluster.py", line 2184, in cassandra.cluster.ControlConnection.shutdown (cassandra/cluster.c:39664)
  File "/usr/lib/python3.4/logging/__init__.py", line 1267, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/lib/python3.4/logging/__init__.py", line 1404, in _log
    fn, lno, func, sinfo = self.findCaller(stack_info)
  File "/home/djeebus/code/other/structlog/src/structlog/stdlib.py", line 32, in findCaller
    f, name = _find_first_app_frame_and_name(['logging'])
  File "/home/djeebus/code/other/structlog/src/structlog/_frames.py", line 44, in _find_first_app_frame_and_name
    name = f.f_globals.get("__name__") or "?"
AttributeError: 'NoneType' object has no attribute 'f_globals'
```

Unfortunately I haven't been able to reproduce this in a simple test. I think it involves the fact that some of the code is written in `C`, but haven't been able to verify that. I have, however, fixed the bug in a pretty simple way. Hopefully this hopes someone else as well!