### PR TITLE
drop missing keys from KeyValueRender

### DIFF
--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -45,7 +45,7 @@ class KeyValueRenderer(object):
                 items = []
                 for key in key_order:
                     value = event_dict.pop(key, None)
-                    if value or not drop_missing:
+                    if value is not None or not drop_missing:
                         items.append((key, value))
                 items += sorted(event_dict.items())
                 return items
@@ -54,7 +54,7 @@ class KeyValueRenderer(object):
                 items = []
                 for key in key_order:
                     value = event_dict.pop(key, None)
-                    if value or not drop_missing:
+                    if value is not None or not drop_missing:
                         items.append((key, value))
                 items += event_dict.items()
                 return items

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -32,8 +32,8 @@ class KeyValueRenderer(object):
     :param list key_order: List of keys that should be rendered in this exact
         order.  Missing keys will be rendered as `None`, extra keys depending
         on *sort_keys* and the dict class unless drop_missing is True.
-    :param bool drop_missing: When True, extra keys in key_order will be dropped rather
-        than rendered as None
+    :param bool drop_missing: When True, extra keys in key_order will be
+        dropped rather than rendered as None
 
     .. versionadded:: 0.2.0
         `key_order`

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -31,19 +31,22 @@ class KeyValueRenderer(object):
     :param bool sort_keys: Whether to sort keys when formatting.
     :param list key_order: List of keys that should be rendered in this exact
         order.  Missing keys will be rendered as `None`, extra keys depending
-        on *sort_keys* and the dict class.
+        on *sort_keys* and the dict class unless drop_missing is True.
+    :param bool drop_missing: When True, extra keys in key_order will be dropped rather
+        than rendered as None
 
     .. versionadded:: 0.2.0
         `key_order`
     """
-    def __init__(self, sort_keys=False, key_order=None):
+    def __init__(self, sort_keys=False, key_order=None, drop_missing=False):
         # Use an optimized version for each case.
         if key_order and sort_keys:
             def ordered_items(event_dict):
                 items = []
                 for key in key_order:
                     value = event_dict.pop(key, None)
-                    items.append((key, value))
+                    if value or not drop_missing:
+                        items.append((key, value))
                 items += sorted(event_dict.items())
                 return items
         elif key_order:
@@ -51,7 +54,8 @@ class KeyValueRenderer(object):
                 items = []
                 for key in key_order:
                     value = event_dict.pop(key, None)
-                    items.append((key, value))
+                    if value or not drop_missing:
+                        items.append((key, value))
                 items += event_dict.items()
                 return items
         elif sort_keys:

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -88,7 +88,8 @@ class TestKeyValueRenderer(object):
         """
         assert (
             r"y='test' b=[3, 4] a=<A(\o/)> z=(1, 2) x=7" ==
-            KeyValueRenderer(key_order=['c', 'y', 'b', 'a', 'z', 'x'], drop_missing=True)
+            KeyValueRenderer(key_order=['c', 'y', 'b', 'a', 'z', 'x'],
+                             drop_missing=True)
             (None, None, event_dict)
         )
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -82,6 +82,16 @@ class TestKeyValueRenderer(object):
             (None, None, event_dict)
         )
 
+    def test_order_missing_dropped(self, event_dict):
+        """
+        Missing keys get dropped
+        """
+        assert (
+            r"y='test' b=[3, 4] a=<A(\o/)> z=(1, 2) x=7" ==
+            KeyValueRenderer(key_order=['c', 'y', 'b', 'a', 'z', 'x'], drop_missing=True)
+            (None, None, event_dict)
+        )
+
     def test_order_extra(self, event_dict):
         """
         Extra keys get sorted if sort_keys=True.
@@ -92,6 +102,19 @@ class TestKeyValueRenderer(object):
             r"c=None y='test' b=[3, 4] a=<A(\o/)> z=(1, 2) x=7 A='A' B='B'" ==
             KeyValueRenderer(key_order=['c', 'y', 'b', 'a', 'z', 'x'],
                              sort_keys=True)
+            (None, None, event_dict)
+        )
+
+    def test_order_sorted_missing_dropped(self, event_dict):
+        """
+        Keys get sorted if sort_keys=True and extras get dropped.
+        """
+        event_dict['B'] = 'B'
+        event_dict['A'] = 'A'
+        assert (
+            r"y='test' b=[3, 4] a=<A(\o/)> z=(1, 2) x=7 A='A' B='B'" ==
+            KeyValueRenderer(key_order=['c', 'y', 'b', 'a', 'z', 'x'],
+                             sort_keys=True, drop_missing=True)
             (None, None, event_dict)
         )
 


### PR DESCRIPTION
Rather than render as None, simply drop any missing keys