### PR TITLE
Don't cache logger

### DIFF
--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -247,15 +247,16 @@ class BoundLoggerLazyProxy(object):
         else:
             ctx = _CONFIG.default_context_class(self._initial_values)
         cls = self._wrapper_class or _CONFIG.default_wrapper_class
-        if not self._logger:
-            self._logger = _CONFIG.logger_factory(*self._logger_factory_args)
+        _logger = self._logger
+        if not _logger:
+            _logger = _CONFIG.logger_factory(*self._logger_factory_args)
 
         if self._processors is None:
             procs = _CONFIG.default_processors
         else:
             procs = self._processors
         logger = cls(
-            self._logger,
+            _logger,
             processors=procs,
             context=ctx,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -223,7 +223,7 @@ class TestBoundLoggerLazyProxy(object):
                 return 5
 
         proxy = BoundLoggerLazyProxy(None)
-        old_b = proxy.bind()
+        proxy.bind()
         configure(logger_factory=F)
         new_b = proxy.bind()
         assert new_b.a() == 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -212,6 +212,18 @@ class TestBoundLoggerLazyProxy(object):
         proxy.bind()
         assert bind != proxy.bind
 
+    def test_bind_doesnt_cache_logger(self):
+        class F(object):
+            "New logger factory with a new attribute"
+            def a(self, *args):
+                return 5
+
+        proxy = BoundLoggerLazyProxy(None)
+        old_b = proxy.bind()
+        configure(logger_factory=F)
+        new_b = proxy.bind()
+        assert new_b.a() == 5
+
     def test_emphemeral(self):
         """
         Calling an unknown method proxy creates a new wrapped bound logger

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -213,6 +213,10 @@ class TestBoundLoggerLazyProxy(object):
         assert bind != proxy.bind
 
     def test_bind_doesnt_cache_logger(self):
+        """
+        Calling configure() changes BoundLoggerLazyProxys immediately.
+        Previous uses of the BoundLoggerLazyProxy don't interfere.
+        """
         class F(object):
             "New logger factory with a new attribute"
             def a(self, *args):


### PR DESCRIPTION
Fix #71 by not caching *any* part of the configuration in the proxy unless explicitly requested. This makes the `_logger` attribute consistent with other parameters of the BoundLoggerLazyProxy such as `_processors`, `_wrapper_class`, and `_context_class`.