### PR TITLE
Fix color of timestamp of first log entry

### DIFF
--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -90,6 +90,7 @@ class ConsoleRenderer(object):
 
     def __call__(self, _, __, event_dict):
         sio = StringIO()
+        sio.write(RESET_ALL)
 
         ts = event_dict.pop("timestamp", None)
         if ts is not None:


### PR DESCRIPTION
The timestamp of the first log entry appeared in black instead of white without sending `RESET_ALL` as first element.
