### PR TITLE
Configure PrintLogger to not append newlines

### DIFF
--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -67,6 +67,16 @@ class TestPrintLogger(object):
         PrintLogger(sio)
         assert sio in WRITE_LOCKS
 
+    def test_nl(self, capsys):
+        """
+        When passing nl=False, a newline character isn't appended to
+        output.
+        """
+        PrintLogger(nl=False).msg('hello')
+        out, err = capsys.readouterr()
+        assert 'hello' == out
+        assert '' == err
+
     @pytest.mark.parametrize("method", STDLIB_MSG_METHODS)
     def test_stdlib_methods_support(self, method):
         """
@@ -91,6 +101,13 @@ class TestPrintLoggerFactory(object):
         """
         l = PrintLoggerFactory(sys.stderr)()
         assert sys.stderr is l._file
+
+    def test_passes_nl(self):
+        """
+        If nl is passed to the factory, it gets passed onto the logger.
+        """
+        l = PrintLoggerFactory(nl=False)()
+        assert False is l._nl
 
     def test_ignores_args(self):
         """


### PR DESCRIPTION
As we were integrating with Sentry, we wanted to leverage our own msgpack renderer, but with msgpack, you wouldn't want to separate messages with newlines and this was causing problems.

So instead of copy/pasting the `PrintLogger` into our own, it'd be nice to just be able to provide this as a kwarg to the `PrintLoggerFactory`.