### PR TITLE
Add ProcessorFormatter for setting different renderers for different loggers

### DIFF
--- a/src/structlog/formatters.py
+++ b/src/structlog/formatters.py
@@ -1,0 +1,39 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the MIT License.  See the LICENSE file in the root of this
+# repository for complete details.
+
+"""
+Processor->Formatter proxy.
+Formatter for native ``logging`` module that uses bound ``structlog`` processor
+to format message.
+"""
+
+import logging
+
+
+class ProcessorFormatter(logging.Formatter):
+    """Custom stdlib logging formatter for structlog ``event_dict`` messages.
+
+    Apply a structlog processor to the ``event_dict`` passed as
+    ``LogRecord.msg`` to convert it to loggable format (a string).
+
+    """
+
+    def __init__(self, processor, fmt=None, datefmt=None, style='%'):
+        """Keep reference to the ``processor``."""
+        super().__init__(fmt=fmt, datefmt=datefmt, style=style)
+        self.processor = processor
+
+    def format(self, record):
+        """Extract structlog's ``event_dict`` from ``record.msg``.
+
+        Process a copy of ``record.msg`` since the some processors modify the
+        ``event_dict`` and the ``LogRecord`` will be used for multiple
+        formatting runs.
+
+        """
+        if isinstance(record.msg, dict):
+            msg_repr = self.processor(
+                record._logger, record._name, record.msg.copy())
+            return msg_repr
+        return record.getMessage()

--- a/src/structlog/formatters.py
+++ b/src/structlog/formatters.py
@@ -19,9 +19,9 @@ class ProcessorFormatter(logging.Formatter):
 
     """
 
-    def __init__(self, processor, fmt=None, datefmt=None, style='%'):
+    def __init__(self, processor, *args, **kwargs):
         """Keep reference to the ``processor``."""
-        super().__init__(fmt=fmt, datefmt=datefmt, style=style)
+        super(ProcessorFormatter, self).__init__(*args, **kwargs)
         self.processor = processor
 
     def format(self, record):

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -189,6 +189,11 @@ def format_exc_info(logger, name, event_dict):
     return event_dict
 
 
+def event_dict_to_message(logger, name, event_dict):
+    """Pass the event_dict to stdlib handler for special formatting."""
+    return (event_dict,), {'extra': {'_logger': logger, '_name': name}}
+
+
 class TimeStamper(object):
     """
     Add a timestamp to `event_dict`.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -119,7 +119,7 @@ class TestProcessing(object):
 
     def test_last_processor_returns_dict(self):
         """
-        If the final processor returns a dict, ``(), the_dict`` is returnend.
+        If the final processor returns a dict, ``(), the_dict`` is returned.
         """
         logger = stub(msg=lambda *args, **kw: (args, kw))
         b = build_bl(logger, processors=[lambda *_: {'event': 'foo'}])

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,55 @@
+import logging
+
+import pytest
+
+from structlog.formatters import ProcessorFormatter
+
+
+@pytest.fixture
+def processor_factory(expected_rep):
+    class TestArgs(object):
+        def __call__(self, *args):
+            self.args = list(args)
+            return expected_rep
+    return TestArgs()
+
+
+class TestProcessorFormatter(object):
+
+    def test_format__dict(self):
+        """
+        If ``record.msg`` is a dict, bound processor call result is returned.
+        """
+        logger = logging.getLogger(__name__)
+        msg = {'foo': 'bar'}
+        record = logger.makeRecord('foobar', logging.DEBUG, 'foo', 42,
+                                   msg, (), False,
+                                   extra={'_name': 'debug',
+                                          '_logger': logger})
+        expected_repr = 'Record representation'
+        ppr = processor_factory(expected_repr)
+        processor_formatter = ProcessorFormatter(ppr)
+
+        actual_repr = processor_formatter.format(record)
+
+        assert ppr.args == [record._logger, record._name, record.msg.copy()]
+        assert expected_repr == actual_repr
+
+    def test_format__not_dict(self):
+        """
+        If ``record.msg`` is not a dict, ``record.getMessage()`` result
+        is returned.
+        """
+        logger = logging.getLogger(__name__)
+        msg = 'not a dict'
+        record = logger.makeRecord('foobar', logging.DEBUG, 'foo', 42,
+                                   msg, (), False,
+                                   extra={'_name': 'debug',
+                                          '_logger': logger})
+        expected_repr = record.getMessage()
+        ppr = processor_factory(expected_repr)
+        processor_formatter = ProcessorFormatter(ppr)
+
+        actual_repr = processor_formatter.format(record)
+
+        assert expected_repr == actual_repr

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -27,12 +27,14 @@ class TestProcessorFormatter(object):
                                    extra={'_name': 'debug',
                                           '_logger': logger})
         expected_repr = 'Record representation'
-        ppr = processor_factory(expected_repr)
-        processor_formatter = ProcessorFormatter(ppr)
+        processor = processor_factory(expected_repr)
+        processor_formatter = ProcessorFormatter(processor)
 
         actual_repr = processor_formatter.format(record)
 
-        assert ppr.args == [record._logger, record._name, record.msg.copy()]
+        assert processor.args == [record._logger,
+                                  record._name,
+                                  record.msg.copy()]
         assert expected_repr == actual_repr
 
     def test_format__not_dict(self):
@@ -47,8 +49,8 @@ class TestProcessorFormatter(object):
                                    extra={'_name': 'debug',
                                           '_logger': logger})
         expected_repr = record.getMessage()
-        ppr = processor_factory(expected_repr)
-        processor_formatter = ProcessorFormatter(ppr)
+        processor = processor_factory(expected_repr)
+        processor_formatter = ProcessorFormatter(processor)
 
         actual_repr = processor_formatter.format(record)
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import datetime
 import json
 import sys
+import logging
 
 import pytest
 import simplejson
@@ -32,6 +33,7 @@ from structlog.processors import (
     _figure_out_exc_info,
     _json_fallback_handler,
     format_exc_info,
+    event_dict_to_message,
 )
 from structlog.threadlocal import wrap_dict
 
@@ -275,6 +277,20 @@ class TestFormatExcInfo(object):
             "exc_info": Exception("no traceback!")
         })
         assert {"exception": "Exception: no traceback!"} == rv
+
+
+class TestEventDictToMessage(object):
+    def test_process(self):
+        """
+        Adapted message for stdlib handler is returned
+        """
+        logger = logging.getLogger()
+        name = 'foobar'
+        event_dict = {'foo': 'bar'}
+        expected_message = ((event_dict,),
+                            {'extra': {'_logger': logger, '_name': name}})
+        actual_message = event_dict_to_message(logger, name, event_dict)
+        assert expected_message == actual_message
 
 
 class TestUnicodeEncoder(object):


### PR DESCRIPTION
…using native logging formatters.
Implementation taken from https://github.com/hynek/structlog/pull/73#issuecomment-222931463
Could be useful along with #78
