### PR TITLE
Handling the case when exc_info is not True but evalues to True

### DIFF
--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -237,10 +237,12 @@ def _figure_out_exc_info(v):
 
     :rtype: tuple
     """
-    if v is True:
-        return sys.exc_info()
-    elif six.PY3 and isinstance(v, BaseException):
+    if six.PY3 and isinstance(v, BaseException):
         return (v.__class__, v, getattr(v, "__traceback__"))
+    elif isinstance(v, tuple):
+        return v
+    elif v:
+        return sys.exc_info()
 
     return v
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -447,25 +447,16 @@ class TestStackInfoRenderer(object):
 class TestFigureOutExcInfo(object):
     def test_obtains_exc_info_on_True(self):
         """
-        If True is passed, obtain exc_info ourselves.
-        """
-        try:
-            0/0
-        except Exception:
-            assert sys.exc_info() == _figure_out_exc_info(True)
-        else:
-            pytest.fail("Exception not raised.")
-
-    def test_obtains_exc_info_on_number(self):
-        """
         If the passed argument evaluates to True obtain exc_info ourselves.
         """
-        try:
-            0/0
-        except Exception:
-            assert sys.exc_info() == _figure_out_exc_info(1)
-        else:
-            pytest.fail("Exception not raised.")
+        true_values = [True, 1, 1.1]
+        for true_value in true_values:
+            try:
+                0/0
+            except Exception:
+                assert sys.exc_info() == _figure_out_exc_info(true_value)
+            else:
+                pytest.fail("Exception not raised.")
 
     @py3_only
     def test_py3_exception_no_traceback(self):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -456,6 +456,17 @@ class TestFigureOutExcInfo(object):
         else:
             pytest.fail("Exception not raised.")
 
+    def test_obtains_exc_info_on_number(self):
+        """
+        If the passed argument evaluates to True obtain exc_info ourselves.
+        """
+        try:
+            0/0
+        except Exception:
+            assert sys.exc_info() == _figure_out_exc_info(1)
+        else:
+            pytest.fail("Exception not raised.")
+
     @py3_only
     def test_py3_exception_no_traceback(self):
         """

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -445,18 +445,19 @@ class TestStackInfoRenderer(object):
 
 
 class TestFigureOutExcInfo(object):
-    def test_obtains_exc_info_on_True(self):
+    @pytest.mark.parametrize('true_value', [
+        True, 1, 1.1
+    ])
+    def test_obtains_exc_info_on_True(self, true_value):
         """
         If the passed argument evaluates to True obtain exc_info ourselves.
         """
-        true_values = [True, 1, 1.1]
-        for true_value in true_values:
-            try:
-                0/0
-            except Exception:
-                assert sys.exc_info() == _figure_out_exc_info(true_value)
-            else:
-                pytest.fail("Exception not raised.")
+        try:
+            0/0
+        except Exception:
+            assert sys.exc_info() == _figure_out_exc_info(true_value)
+        else:
+            pytest.fail("Exception not raised.")
 
     @py3_only
     def test_py3_exception_no_traceback(self):


### PR DESCRIPTION
According to the documentation [https://docs.python.org/2/library/logging.html#logging.Logger.debug] the exc_info argument should support not only boolean values, but also values evaluating to True.
This fix should solve the case when someone is using:

`log.debug('Debug message', exc_info=1)`

