### PR TITLE
Fix stdlib errors being logged as exceptions sometimes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Changes:
 
 - Add *colors* argument to ``structlog.dev.ConsoleRenderer`` and make it the default renderer.
   `#78 <https://github.com/hynek/structlog/pull/78>`_
+- Fix bug with Python 3 and ``structlog.stdlib.log`` function. Error log level was not reproductible and was logged as exception
+  one time out of two.
+  `#92 <https://github.com/hynek/structlog/pull/92>`_
 
 
 ----

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -302,7 +302,7 @@ _NAME_TO_LEVEL = {
 
 _LEVEL_TO_NAME = dict(
     (v, k) for k, v in _NAME_TO_LEVEL.items()
-    if k not in ("warn", "notset")
+    if k not in ("warn", "exception", "notset", )
 )
 
 


### PR DESCRIPTION
stdlib error log records were sometimes logged with exception level, sometimes
logged with error level by structlog. This is due to the non 1-1 mapping
between log levels and log names (some levels have the same name). If the
developer adds a new log name that conflicts with an already existing log
level without blacklisting it, it produces the unexpected behavior. It's even
random in Python 3: because of the hash seed, it will always produce the same
result in the same python interpreter instance, but will vary according to the
interpreter instance.

The problem is that once the mistake is done, it's pretty complicated to debug.
And it's even more complicated to write a test (since you will never notice a
behavior change in the same python instance). I think it would be a good idea
to add a disclaimer message at least. Feel free to add a test for this to
prevent future errors and time loss if you have any idea on how to write it.