### PR TITLE
Suggestion for using stdlib BoundLogger with third-party apps.

### DIFF
--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -358,9 +358,9 @@ class LoggerFactory(object):
         logger = logging.getLogger(name)
 
         if self._handlers is not None:
-            logger.propagate = False  # We don't propagate structlog logs to
-                                      # prevent them from being infinitely
-                                      # processed by a parent _WrappedLogger.
+            # We don't propagate structlog logs to prevent them from being
+            # infinitely processed by a parent _WrappedLogger.
+            logger.propagate = False
             self._override_handlers(logger)
 
         return logger

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -156,7 +156,8 @@ def log_record():
 class TestHandler(object):
     def test_logs_are_emitted_to_structlog(self, log_record, monkeypatch):
         bound_logger = BoundLogger(ReturnLogger(), [return_method_name], {})
-        monkeypatch.setattr("structlog.stdlib.get_logger", lambda: bound_logger)
+        monkeypatch.setattr("structlog.stdlib.get_logger",
+                            lambda: bound_logger)
 
         log_stub = call_recorder(lambda *args, **kw: None)
         monkeypatch.setattr(bound_logger, 'log', log_stub)
@@ -190,7 +191,8 @@ class TestWrapHandler(object):
         )
 
         logger.error(u'foo')
-        get_logger('TestWrapHandler.test_wrap_handler_emit.child').error(u'bar')
+        get_logger('TestWrapHandler.test_wrap_handler_emit.child')\
+            .error(u'bar')
 
         logs = stream.getvalue()
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import io
 import os
 
 import logging
@@ -11,6 +12,7 @@ import logging
 import pytest
 from pretend import call_recorder
 
+from structlog._config import get_logger, configure
 from structlog._loggers import ReturnLogger
 from structlog.exceptions import DropEvent
 from structlog.stdlib import (
@@ -23,21 +25,12 @@ from structlog.stdlib import (
     add_log_level,
     add_logger_name,
     _FixedFindCallerLogger,
+    Handler,
+    wrap_handler,
 )
 
 from .additional_frame import additional_frame
 from .utils import py3_only
-
-
-def build_bl(logger=None, processors=None, context=None):
-    """
-    Convenience function to build BoundLogger with sane defaults.
-    """
-    return BoundLogger(
-        logger or ReturnLogger(),
-        processors,
-        {}
-    )
 
 
 def return_method_name(_, method_name, __):
@@ -117,6 +110,91 @@ class TestLoggerFactory(object):
         """
         l = LoggerFactory()('foo')
         assert 'foo' == l.name
+
+    def test_specified_handlers_are_used(self):
+        """
+        Assert that LoggerFactory uses provided handlers.
+        """
+        stream1 = io.StringIO()
+        stream2 = io.StringIO()
+        h1 = logging.StreamHandler(stream1)
+        h2 = logging.StreamHandler(stream2)
+        logger = LoggerFactory(handlers=[h1, h2])()
+        logger.error(u'foo')
+        assert stream1.getvalue() == u'foo\n'
+        assert stream2.getvalue() == u'foo\n'
+
+    def test_logs_are_not_propagated_when_handlers_are_specified(self):
+        """
+        Assert that LoggerFactory does not propagate it's handlers if
+        overridden. This is to prevent multiple processing of the log.
+        """
+        parent_logger = logging.getLogger(
+            'TestLoggerFactory.test_provided_handlers_are_not_propagated'
+        )
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        parent_logger = parent_logger.addHandler(handler)
+
+        child_logger = LoggerFactory(handlers=[logging.NullHandler()])(
+            'TestLoggerFactory.test_provided_handlers_are_not_propagated.child'
+        )
+        child_logger.error('foo')
+
+        assert stream.getvalue() == ''
+
+
+@pytest.fixture
+def log_record():
+    """
+    Returns a LogRecord.
+    """
+    return logging.LogRecord('fixture_log_record', logging.DEBUG, __file__, 42,
+                             'foo', (), {'foo': 'bar'})
+
+
+class TestHandler(object):
+    def test_logs_are_emitted_to_structlog(self, log_record, monkeypatch):
+        bound_logger = BoundLogger(ReturnLogger(), [return_method_name], {})
+        monkeypatch.setattr("structlog.stdlib.get_logger", lambda: bound_logger)
+
+        log_stub = call_recorder(lambda *args, **kw: None)
+        monkeypatch.setattr(bound_logger, 'log', log_stub)
+
+        handler = Handler()
+        handler.emit(log_record)
+
+        log_stub_call_args = log_stub.calls[0].args
+        log_stub_call_kwargs = log_stub.calls[0].kwargs
+        assert log_stub_call_args[0] == logging.DEBUG
+        assert log_stub_call_args[1] == log_record.getMessage()
+        assert log_stub_call_kwargs['name'] == 'fixture_log_record'
+        assert log_stub_call_kwargs['exc_info'] == {'foo': 'bar'}
+
+
+class TestWrapHandler(object):
+    def test_wrap_handler_emit(self, log_record, monkeypatch):
+        def processor(_, __, event_dict):
+            return event_dict['event']
+
+        stream = io.StringIO()
+        wrapped_handler = logging.StreamHandler(stream)
+        handler = wrap_handler(wrapped_handler)()
+        logger = logging.getLogger('TestWrapHandler.test_wrap_handler_emit')
+        logger.addHandler(handler)
+
+        configure(
+            processors=[processor],
+            wrapper_class=BoundLogger,
+            logger_factory=LoggerFactory(handlers=logger.handlers)
+        )
+
+        logger.error(u'foo')
+        get_logger('TestWrapHandler.test_wrap_handler_emit.child').error(u'bar')
+
+        logs = stream.getvalue()
+
+        assert logs == 'foo\nbar\n'
 
 
 class TestFilterByLevel(object):


### PR DESCRIPTION
Hi there,

Here are some suggestions to improve stdlib. It allows to use the stdlib.BoundLogger, even when defining a root handler (to pass third-party apps logs through structlog's pipeline). Not sure my approach is really logical and elegant though (maybe closer to a POC) and suggestions/improvements are welcome. 

- Add a `stdlib.Handler` class that helps forward third-party apps logs through structlog. May fit to most use cases. However, can lead to recursion issues if you persist on using `stdlib.LogFactory`. To overcome this, I did some extra-work (see second bullet-point).

  Typical use-case: output third-party apps + structlog logs to stdout.
```python
import logging
import sys

import structlog


root_logger = logging.getLogger()
handler = structlog.stdlib.Handler()
root_logger.addHandler(handler)
root_logger.setLevel(logging.INFO)

structlog.configure(
    processors=[
        structlog.stdlib.add_log_level,
        structlog.stdlib.PositionalArgumentsFormatter(),
        structlog.processors.TimeStamper(fmt="iso"),
        structlog.processors.StackInfoRenderer(),
        structlog.processors.format_exc_info,
        # structlog.processors.JSONRenderer(),
        structlog.dev.ConsoleRenderer(),
    ],
    context_class=dict,
    wrapper_class=structlog.stdlib.BoundLogger,
    cache_logger_on_first_use=True,
)

logging.getLogger('foo').warning("logging!")
logging.getLogger('foo.bar').warning("logging again!")

structlog.get_logger().warning("we can also log from structlog!")
```

- Add a `stdlib._HandlerWrapper` class and a `stdlib.wrap_handler` function that allows to output structlog log through logging modules handlers (this required some more changes in `stdlib.LoggerFactory` to work properly). This wrapper prevents structlog from recursing.

Typical use-case: output third-party apps through structlog, and even output everything to vanilla handlers.

```python
import io
import logging
import sys

import structlog


root_logger = logging.getLogger()
s = io.StringIO()
handler = structlog.stdlib.wrap_handler(logging.StreamHandler(s))()
root_logger.addHandler(handler)
root_logger.setLevel(logging.INFO)

structlog.configure(
    processors=[
        structlog.stdlib.add_log_level,
        structlog.stdlib.PositionalArgumentsFormatter(),
        structlog.processors.TimeStamper(fmt="iso"),
        structlog.processors.StackInfoRenderer(),
        structlog.processors.format_exc_info,
        # structlog.processors.JSONRenderer(),
        structlog.dev.ConsoleRenderer(),
    ],
    context_class=dict,
    wrapper_class=structlog.stdlib.BoundLogger,
    logger_factory=structlog.stdlib.LoggerFactory(handlers=root_logger.handlers),
    cache_logger_on_first_use=True,
)

logging.getLogger('foo').warning("logging!")
logging.getLogger('foo.bar').warning("logging again!")

structlog.get_logger().warning("we can also log from structlog!")

print(s.getvalue())  # Everything was logged
```

Thus, this allows to use stdlib.filter_by_level and probably some other stuff I did not think of.

Cheers.