### PR TITLE
Fix dev.ConsoleRenderer wrt. key 'event'

### DIFF
--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -168,7 +168,7 @@ class ConsoleRenderer(object):
                 # can be a number if timestamp is UNIXy
                 self._styles.timestamp + str(ts) + self._styles.reset + " "
             )
-        level = event_dict.pop("level",  None)
+        level = event_dict.pop("level", None)
         if level is not None:
             sio.write(
                 "[" + self._level_to_color[level] +
@@ -176,7 +176,7 @@ class ConsoleRenderer(object):
                 self._styles.reset + "] "
             )
 
-        event = event_dict.pop("event")
+        event = self._repr(event_dict.pop("event", "--"))
         if event_dict:
             event = _pad(event, self._pad_event) + self._styles.reset + " "
         else:

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -176,7 +176,8 @@ class ConsoleRenderer(object):
                 self._styles.reset + "] "
             )
 
-        event = self._repr(event_dict.pop("event", "--"))
+        # event = self._repr(event_dict.pop("event", "--"))
+        event = str(event_dict.pop("event", "--"))
         if event_dict:
             event = _pad(event, self._pad_event) + self._styles.reset + " "
         else:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -178,6 +178,21 @@ class TestConsoleRenderer(object):
             styles.kv_value + "bar" + styles.reset
         ) == rv
 
+    def test_missing_event(self, cr, styles, padded):
+        """
+        ConsoleRenderer use with a event_dict which has no `event` key
+        """
+        cr(None, None, {"no_event": "test"})
+        # assert no KeyError is raised
+
+    def test_event_not_a_str(self, cr, styles, padded):
+        """
+        ConsoleRenderer use with a event_dict
+        where the value of the `event` key no not a string
+        """
+        cr(None, None, {"event": 42})
+        # assert no TypeError is raised
+
     def test_everything(self, cr, styles, padded):
         """
         Put all cases together.


### PR DESCRIPTION
handle the cases if 'event' is missing in event_dict or not a string