### PR TITLE
Fix exc_info and race condition in ProcessorFormatter

### DIFF
--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -421,16 +421,16 @@ class ProcessorFormatter(logging.Formatter):
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage()}
 
+            # Add stack-related attributes to event_dict and unset them
+            # on the record copy so that the base implementation wouldn't
+            # append stacktraces to the output
+            record.exc_text = None
             if record.exc_info:
                 ed['exc_info'] = record.exc_info
-            if record.stack_info:
+                record.exc_info = None
+            if PY3 and record.stack_info:
                 ed['stack_info'] = record.stack_info
-
-            # Unset some attributes on the record copy so that the base
-            # implementation wouldn't append stacktraces to the output
-            record.exc_info = None
-            record.stack_info = None
-            record.exc_text = None
+                record.stack_info = None
 
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -393,11 +393,13 @@ class ProcessorFormatter(logging.Formatter):
 
     .. versionadded:: 17.1.0
     """
-    def __init__(self, processor, foreign_pre_chain=None, *args, **kwargs):
+    def __init__(self, processor, foreign_pre_chain=None,
+                 unset_record_stack=False, *args, **kwargs):
         fmt = kwargs.pop("fmt", "%(message)s")
         super(ProcessorFormatter, self).__init__(*args, fmt=fmt, **kwargs)
         self.processor = processor
         self.foreign_pre_chain = foreign_pre_chain
+        self.unset_record_stack = unset_record_stack
 
     def format(self, record):
         """
@@ -424,13 +426,16 @@ class ProcessorFormatter(logging.Formatter):
             # Add stack-related attributes to event_dict and unset them
             # on the record copy so that the base implementation wouldn't
             # append stacktraces to the output
-            record.exc_text = None
             if record.exc_info:
                 ed['exc_info'] = record.exc_info
-                record.exc_info = None
             if PY3 and record.stack_info:
                 ed['stack_info'] = record.stack_info
-                record.stack_info = None
+
+            if self.unset_record_stack:
+                record.exc_text = None
+                record.exc_info = None
+                if PY3:
+                    record.stack_info = None
 
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).


### PR DESCRIPTION
I'm totally new to structlog so it's possible that I just missed something, but I think there's an issue with exception formatting and some sort of race condition in ProcessorFormatter. Let me illustrate that with a code example:

```python
#!/usr/bin/env python3
import logging
import structlog
import sys

structlog.configure(
    processors=[
        structlog.stdlib.add_log_level,
        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
    ],
    logger_factory=structlog.stdlib.LoggerFactory(),
    wrapper_class=structlog.stdlib.BoundLogger,
)

handler_structlog = logging.StreamHandler(stream=sys.stdout)
handler_structlog.setFormatter(structlog.stdlib.ProcessorFormatter(
    processor=structlog.processors.JSONRenderer(),
    # processor=structlog.dev.ConsoleRenderer(colors=False),
    foreign_pre_chain=[
        structlog.processors.format_exc_info,
    ],
))

handler_classic = logging.StreamHandler(stream=sys.stdout)
handler_classic.setFormatter(logging.Formatter(
    fmt="%(asctime)s - %(levelname)s - %(message)s",
))

logger1 = logging.getLogger('L1')
logger1.addHandler(handler_classic)
logger1.addHandler(handler_structlog)

logger2 = logging.getLogger('L2')
logger2.addHandler(handler_structlog)
logger2.addHandler(handler_classic)

for logger in (logger1, logger2):
    try:
        raise RuntimeError("ohnoes")
    except Exception:
        logger.exception("the worst has happened")

    print("--")
    print()
```

Here I'm creating two stdlib handlers: one that's using ProcessorFormatter and one with the standard `logging.Formatter`.
Then I create two loggers, each having those two handlers but in different order.

If I run it with the latest release of structlog, I'll get the following output:
```
2017-05-02 22:30:47,560 - ERROR - the worst has happened
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
{"event": "the worst has happened"}
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
--

{"event": "the worst has happened"}
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
2017-05-02 22:30:47,560 - ERROR - {"event": "the worst has happened"}
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
--
```

I see a couple of issues here:
1. Traceback from the exception got printed outside of the json document because processor functions hadn't had access to `exc_info` field.
2. The logger in which structlog formatter had been used first, printed out the json document twice because the record had been mutated in ProcessorFormatter.

I tried to pull together a patch and after the fix the output looks like I would expect it to:
```
2017-05-02 22:31:58,257 - ERROR - the worst has happened
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
{"event": "the worst has happened", "exception": "Traceback (most recent call last):\n  File \"/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py\", line 30, in <module>\n    raise RuntimeError(\"ohnoes\")\nRuntimeError: ohnoes"}
--

{"event": "the worst has happened", "exception": "Traceback (most recent call last):\n  File \"/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py\", line 30, in <module>\n    raise RuntimeError(\"ohnoes\")\nRuntimeError: ohnoes"}
2017-05-02 22:31:58,257 - ERROR - the worst has happened
Traceback (most recent call last):
  File "/Users/andrey/dev/src/github.com/andreiko/sandbox/sandbox.py", line 30, in <module>
    raise RuntimeError("ohnoes")
RuntimeError: ohnoes
--
```

1. Exception is inside the json document
2. Handler that came after ProcessorFormatter printed the original record message