### PR TITLE
Allow stdlib configuration to be serializable.

### DIFF
--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -127,14 +127,20 @@ You can leave rendering for later and yet use ``structlog``’s renderers for it
             "disable_existing_loggers": False,
             "formatters": {
                 "plain": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processor": structlog.dev.ConsoleRenderer(colors=False),
+                    "()": "structlog.stdlib.ProcessorFormatter",
+                    "processor": "structlog.dev.ConsoleRenderer",
+                    "processor_kwargs": {"colors": False},
                     "foreign_pre_chain": pre_chain,
+                    # alternatively
+                    # "foreign_pre_chain": "mymodule.pre_chain",
                 },
                 "colored": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processor": structlog.dev.ConsoleRenderer(colors=True),
+                    "()": "structlog.stdlib.ProcessorFormatter",
+                    "processor": "structlog.dev.ConsoleRenderer",
+                    "processor_kwargs": {"colors": True},
                     "foreign_pre_chain": pre_chain,
+                    # alternatively
+                    # "foreign_pre_chain": "mymodule.pre_chain",
                 },
             },
             "handlers": {


### PR DESCRIPTION
This merge request allows the stdlib configuration to be serializable, so that it can lay a bit more in configuration files instead of python code.

If it's convincing, I'd like to generalize this to all structlog configuration and even allow serializable processors definition, so that the configuration work can be in its right place, that is to say in configuration files. The final goal is to avoid using ugly conditionals to configure structlog. We should be able to just provide a self-explanatory configuration file.