### PR TITLE
Support DropEvent in foreign_pre_chain

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ freezegun>=0.2.8
 pretend
 pytest
 simplejson
+twisted

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -127,14 +127,20 @@ You can leave rendering for later and yet use ``structlog``’s renderers for it
             "disable_existing_loggers": False,
             "formatters": {
                 "plain": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processor": structlog.dev.ConsoleRenderer(colors=False),
+                    "()": "structlog.stdlib.ProcessorFormatter",
+                    "processor": "structlog.dev.ConsoleRenderer",
+                    "processor_kwargs": {"colors": False},
                     "foreign_pre_chain": pre_chain,
+                    # alternatively
+                    # "foreign_pre_chain": "mymodule.pre_chain",
                 },
                 "colored": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processor": structlog.dev.ConsoleRenderer(colors=True),
+                    "()": "structlog.stdlib.ProcessorFormatter",
+                    "processor": "structlog.dev.ConsoleRenderer",
+                    "processor_kwargs": {"colors": True},
                     "foreign_pre_chain": pre_chain,
+                    # alternatively
+                    # "foreign_pre_chain": "mymodule.pre_chain",
                 },
             },
             "handlers": {

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -540,3 +540,24 @@ class TestProcessorFormatter(object):
             "",
             "",
         ) == capsys.readouterr()
+
+    def test_exceptions_are_handled(self, configure_for_pf, capsys):
+        """
+        Test that exceptions other than DropEvent are still handled.
+        """
+        def fail(logger, method_name, event_dict):
+            raise Exception
+        configure_logging((fail, ))
+        configure(
+            processors=[
+                ProcessorFormatter.wrap_for_formatter,
+            ],
+            logger_factory=LoggerFactory(),
+            wrapper_class=BoundLogger,
+        )
+
+        logging.getLogger().warning("foo")
+
+        out, err = capsys.readouterr()
+        assert "" == out
+        assert "raise Exception" in err


### PR DESCRIPTION
Hi,

Here is a proof that it's possible to support `DropEvent` in `foreign_pre_chain` processors without too much overhead.  This fixes #113. It's based on my work on #114.