### PR TITLE
Clear args on LogRecords after rendering them in ProcessorFormatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changes:
 - Clear log record args in ``structlog.stdlib.ProcessorFormatter`` after rendering.
   This fix is for you if you tried to use it and got ``TypeError: not all arguments converted during string formatting`` exceptions.
   `#116 <https://github.com/hynek/structlog/issues/116>`_
+  `#117 <https://github.com/hynek/structlog/issues/117>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Changes:
 
 - ``structlog.stdlib.add_logger_name()`` now works in ``structlog.stdlib.ProcessorFormatter``'s ``foreign_pre_chain``.
   `#112 <https://github.com/hynek/structlog/issues/112>`_
+- Clear log record args in ``structlog.stdlib.ProcessorFormatter`` after rendering.
+  This fix is for you if you tried to use it and got ``TypeError: not all arguments converted during string formatting`` exceptions.
+  `#116 <https://github.com/hynek/structlog/issues/116>`_
 
 
 ----

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -420,6 +420,7 @@ class ProcessorFormatter(logging.Formatter):
             logger = None
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage(), "_record": record}
+            record.args = ()
 
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).
@@ -429,7 +430,6 @@ class ProcessorFormatter(logging.Formatter):
             del ed["_record"]
 
         record.msg = self.processor(logger, meth_name, ed)
-        record.args = ()
         return super(ProcessorFormatter, self).format(record)
 
     @staticmethod

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -429,6 +429,7 @@ class ProcessorFormatter(logging.Formatter):
             del ed["_record"]
 
         record.msg = self.processor(logger, meth_name, ed)
+        record.args = ()
         return super(ProcessorFormatter, self).format(record)
 
     @staticmethod

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -432,6 +432,22 @@ class TestProcessorFormatter(object):
             "foo [in test_foreign_delegate]\n",
         ) == capsys.readouterr()
 
+    def test_clears_args(self, capsys, configure_for_pf):
+        """
+        We render our log records before sending it back to logging.  Therefore
+        we must clear `LogRecord.args` otherwise the user gets an
+        `TypeError: not all arguments converted during string formatting.` if
+        they use positional formatting in stdlib logging.
+        """
+        configure_logging(None)
+
+        logging.getLogger().warning("hello %s.", "world")
+
+        assert (
+            "",
+            "hello world. [in test_clears_args]\n",
+        ) == capsys.readouterr()
+
     def test_foreign_pre_chain(self, configure_for_pf, capsys):
         """
         If foreign_pre_chain is an iterable, it's used to pre-process


### PR DESCRIPTION
This fixes #116 and *probably* http://stackoverflow.com/questions/43855507/configuring-and-using-structlog-with-django .

@if-fi did I miss something obvious that will break everything for everyone? also cc @gilbsgilbs who seems to know a lot more about stdlib logging than I. :)
