### PR TITLE
Fix exc_info and race condition in ProcessorFormatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- ``structlog.stdlib.ProcessorFormatter`` now accepts *keep_exc_info* and *keep_stack_info* arguments to control what to do with this information on log records.
+  Most likely you want them both to be ``False`` therefore it's the default.
+  `#109 <https://github.com/hynek/structlog/issues/109>`_
 - ``structlog.stdlib.add_logger_name()`` now works in ``structlog.stdlib.ProcessorFormatter``'s ``foreign_pre_chain``.
   `#112 <https://github.com/hynek/structlog/issues/112>`_
 - Clear log record args in ``structlog.stdlib.ProcessorFormatter`` after rendering.


### PR DESCRIPTION
Based on / fixes #109 

Hey @andreiko I tried to push it to your branch but I failed at git hard (due to the changes in master) so here’s a new pull request with some changes (and split up of stack_info & exc_info handling).

Does this still fix your problem and do you agree with the approach?