### PR TITLE
Send colored logs to non-tty destinations + fix for a unit test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changes:
 - Empty strings are valid events now.
   `#110 <https://github.com/hynek/structlog/issues/110>`_
 
+- ``structlog.dev.ConsoleRenderer`` now accepts a *force_colors* argument to output colored logs even if the destination is not a tty. 
+  Use this option if your logs are stored in files that are intended to be streamed to the console.
 
 ----
 

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -99,6 +99,9 @@ class ConsoleRenderer(object):
 
     :param int pad_event: Pad the event to this many characters.
     :param bool colors: Use colors for a nicer output.
+    :param bool force_colors: Force colors even for non-tty destinations.
+        Use this option if your logs are stored in a file that is meant
+        to be streamed to the console.
     :param bool repr_native_str: When ``True``, :func:`repr()` is also applied
         to native strings (i.e. unicode on Python 3 and bytes on Python 2).
         Setting this to ``False`` is useful if you want to have human-readable
@@ -114,7 +117,7 @@ class ConsoleRenderer(object):
     .. versionadded:: 17.1 *repr_native_str*
     """
     def __init__(self, pad_event=_EVENT_WIDTH, colors=True,
-                 repr_native_str=False):
+                 force_colors=False, repr_native_str=False):
         if colors is True:
             if colorama is None:
                 raise SystemError(
@@ -124,7 +127,12 @@ class ConsoleRenderer(object):
                     )
                 )
 
-            colorama.init()
+            if force_colors:
+                colorama.deinit()
+                colorama.init(strip=False)
+            else:
+                colorama.init()
+
             styles = _ColorfulStyles
         else:
             styles = _PlainStyles
@@ -168,7 +176,7 @@ class ConsoleRenderer(object):
                 # can be a number if timestamp is UNIXy
                 self._styles.timestamp + str(ts) + self._styles.reset + " "
             )
-        level = event_dict.pop("level",  None)
+        level = event_dict.pop("level", None)
         if level is not None:
             sio.write(
                 "[" + self._level_to_color[level] +

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -228,6 +228,29 @@ class TestConsoleRenderer(object):
         assert dev._PlainStyles is plain_cr._styles
         assert "[info     ] event                          foo=bar" == rv
 
+    def test_colorama_force_colors(self, styles, padded):
+        """
+        If force_colors is True, use colors even if
+        the destination is non-tty.
+        """
+        cr = dev.ConsoleRenderer(
+            colors=dev._has_colorama, force_colors=dev._has_colorama)
+
+        rv = cr(None, None, {
+            "event": "test", "level": "critical", "foo": "bar"
+        })
+
+        assert (
+            "[" + dev.RED + styles.bright +
+            dev._pad("critical", cr._longest_level) +
+            styles.reset + "] " +
+            padded +
+            styles.kv_key + "foo" + styles.reset + "=" +
+            styles.kv_value + "bar" + styles.reset
+        ) == rv
+
+        assert not dev._has_colorama or dev._ColorfulStyles is cr._styles
+
     @pytest.mark.parametrize("rns", [True, False])
     def test_repr_native_str(self, rns):
         """

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -115,13 +115,13 @@ class TestExtractStuffAndWhy(object):
         """
         f = Failure(ValueError())
         assert (
-            (f, "foo", {}) ==
+            ({'value': f}, "foo", {}) ==
             _extractStuffAndWhy({"_why": "foo",
-                                 "_stuff": f})
+                                 "_stuff": {'value': f}})
         )
         assert (
-            (f, None, {}) ==
-            _extractStuffAndWhy({"_stuff": f})
+            ({'value': f}, None, {}) ==
+            _extractStuffAndWhy({"_stuff": {'value': f}})
         )
 
     def test_handlesMissingFailure(self):
@@ -154,6 +154,7 @@ class TestEventAdapter(object):
     """
     Some tests here are redundant because they predate _extractStuffAndWhy.
     """
+
     def test_EventAdapterFormatsLog(self):
         la = EventAdapter(_render_repr)
         assert "{'foo': 'bar'}" == la(None, 'msg', {'foo': 'bar'})


### PR DESCRIPTION
Add option to ConsoleRenderer for sending colored logs to non-tty destinations. 
The main use case is that of files meant to be streamed to the console. 
We use this with docker logs.
Also included is a fix for a unit test.