### PR TITLE
[DOCS] fix threadlocal docs to provide correct example

### DIFF
--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -61,13 +61,12 @@ Within one thread, every instance of the returned class will have a *common* ins
    <WrappedDict-...({'a': 1, 'b': 2, 'c': 3})>
 
 
-Then use an instance of the generated class as the context class::
+To enable thread local context, then, use the generated class as the context class::
 
-   configure(context_class=WrappedDictClass())
+   configure(context_class=WrappedDictClass)
 
 .. note::
-   **Remember**: the instance of the class *doesn't* matter.
-   Only the class *type* matters because *all* instances of one class *share* the *same* data.
+   Creation of a new ``BoundLogger`` initializes the logger's context as ``context_class(initial_values)``, and then adds any values passed via ``.bind()``. As all instances of a wrapped dict-like class share the same data, in the case above, the new logger's context will contain all previously bound values in addition to the new ones.
 
 :func:`structlog.threadlocal.wrap_dict` returns always a completely *new* wrapped class:
 


### PR DESCRIPTION
Threadlocal docs currently say to use an _instance_ of `WrappedDictClass` as the `context_class`, i.e.:
```
configure(context_class=WrappedDictClass())
```

The call above doesn't actually set `context_class` at all, b/c an empty `WrappedDictClass` instance evaluates to falsey and so fails the `if context_class` check in [`configure()`](https://github.com/hynek/structlog/blob/master/src/structlog/_config.py#L164). If we manage to actually set `context_class` as an _instance_ rather than a _class_, attempts to `.bind()` result in error: 
```
TypeError: 'WrappedDict-f8fcd814-393b-4ddf-b539-c55e7bd04e62' object is not callable
```

Worth noting that the [threadlocal tests](https://github.com/maiamcc/structlog/blob/master/tests/test_threadlocal.py#L37) all test behavior with a `wrap_dict` _class_, not _instance_.