### PR TITLE
twisted: don't encapsulate failures twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       env: TOXENV=py27-colorama
     - python: "3.6"
       env: TOXENV=py36-colorama
+    - python: "3.6"
+      env: TOXENV=py36-oldtwisted
 
 
     # Meta

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Changes:
 
 - Empty strings are valid events now.
   `#110 <https://github.com/hynek/structlog/issues/110>`_
-
+- Do not encapsulate Twisted failures twice with newer versions of Twisted.
+  `#144 <https://github.com/hynek/structlog/issues/144>`_
 
 ----
 

--- a/src/structlog/twisted.py
+++ b/src/structlog/twisted.py
@@ -107,7 +107,7 @@ def _extractStuffAndWhy(eventDict):
         _stuff = Failure()
     # Either we used the error ourselves or the user supplied one for
     # formatting.  Avoid log.err() to dump another traceback into the log.
-    if isinstance(_stuff, BaseException):
+    if isinstance(_stuff, BaseException) and not isinstance(_stuff, Failure):
         _stuff = Failure(_stuff)
     if PY2:
         sys.exc_clear()

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
-envlist = {py27,py34,py35,py36,pypy}-{threads,greenlets},{py27,py36}-colorama,flake8,docs,readme,manifest,coverage-report
+envlist = {py27,py34,py35,py36,pypy}-{threads,greenlets},{py27,py36}-{colorama,oldtwisted},flake8,docs,readme,manifest,coverage-report
 
 
 [testenv]
 deps =
     -rdev-requirements.txt
     greenlets: greenlet
-    twisted
+    threads,greenlets,colorama: twisted
+    oldtwisted: twisted < 17
     colorama: colorama
     py36: python-rapidjson
 setenv =
     PYTHONHASHSEED = 0
 commands = coverage run --parallel -m pytest {posargs}
-
 
 [testenv:flake8]
 basepython = python3.6


### PR DESCRIPTION
If a failure is already a Failure instance, don't encapsulate it into
a Failure. Keep it as is.

Fix #144 

Note that I have no clue if this is actually correct. This fixes the failing test and it doesn't seem dumb to do that. I didn't investigate what changes triggered this problem. Maybe `Failure` was not a `BaseException` in the past.