### PR TITLE
lazy evaluation of args for _proxy_to_logger

### DIFF
--- a/src/structlog/_base.py
+++ b/src/structlog/_base.py
@@ -149,7 +149,7 @@ class BoundLoggerBase(object):
                 "string."
             )
 
-    def _proxy_to_logger(self, method_name, event=None, **event_kw):
+    def _proxy_to_logger(self, method_name, event=None, *args, **event_kw):
         """
         Run processor chain on event & call *method_name* on wrapped logger.
 
@@ -162,6 +162,8 @@ class BoundLoggerBase(object):
             user called because it also get passed into processors.
         :param event: The event -- usually the first positional argument to a
             logger.
+        :param args: argument to render into the event (for compatibility with
+            lazy argument evaluation of logging.* functions)
         :param event_kw: Additional event keywords.  For example if someone
             calls ``log.msg('foo', bar=42)``, *event* would to be ``'foo'``
             and *event_kw* ``{'bar': 42}``.
@@ -172,6 +174,8 @@ class BoundLoggerBase(object):
 
             See also :doc:`custom-wrappers`.
         """
+        if args:
+            event = event % args
         try:
             args, kw = self._process_event(method_name, event, event_kw)
             return getattr(self._logger, method_name)(*args, **kw)


### PR DESCRIPTION
Allow the smooth transition of module from logging to structlog

Use case:
- the developer has a module that uses `logging`, and also likes lazy evaluation of arguments, for example:

    log = logging.getLogger(__name__)
    logging.debug("my value is %s", myvalue)

- He wishes to transition to `structlog`, so he replaces by 

    from structlog import get_logger
    log = get_logger()

- the developer does not want to modify anything else
 
In unit test it may fail with the following error:
```
TypeError: _proxy_to_logger() takes from 2 to 3 positional arguments but 4 were given
```

Because `BoundLoggerBase._proxy_to_logger` does not accept `*args` by default.

With this patch, we allow transparently to have lazy evaluated arguments, allowing the use of 

    log = structlog.get_logger()
    logging.debug("my value is %s", myvalue)

Signed-off-by: Gaetan Semet <gaetan@xeberon.net>