### PR TITLE
Add log level numbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``structlog.stdlib.add_log_level_number`` processor to add level number of log level to the event dictionary. Can be used to simplify log filtering.
+  `#151 <https://github.com/hynek/structlog/pull/151>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Added ``structlog.stdlib.add_log_level_number`` processor to add level number of log level to the event dictionary. Can be used to simplify log filtering.
+- Added :meth:`~structlog.stdlib.add_log_level_number` processor to add level number of log level to the event dictionary. Can be used to simplify log filtering.
   `#151 <https://github.com/hynek/structlog/pull/151>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Added :meth:`~structlog.stdlib.add_log_level_number` processor to add level number of log level to the event dictionary. Can be used to simplify log filtering.
+- Added ``structlog.stdlib.add_log_level_number`` processor to add level number of log level to the event dictionary. Can be used to simplify log filtering.
   `#151 <https://github.com/hynek/structlog/pull/151>`_
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -187,6 +187,8 @@ API Reference
 
 .. autofunction:: filter_by_level
 
+.. autofunction:: add_log_level_number
+
 .. autofunction:: add_log_level
 
 .. autofunction:: add_logger_name

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -187,9 +187,9 @@ API Reference
 
 .. autofunction:: filter_by_level
 
-.. autofunction:: add_log_level_number
-
 .. autofunction:: add_log_level
+
+.. autofunction:: add_log_level_number
 
 .. autofunction:: add_logger_name
 

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -58,11 +58,17 @@ Processors
 :func:`~structlog.stdlib.add_logger_name`:
    Adds the name of the logger to the event dictionary under the key ``logger``.
 
-:func:`~structlog.stdlib.add_log_level_number`:
-   Adds the log level number to the event dictionary under the key ``level_number``.
-
 :func:`~structlog.stdlib.add_log_level`:
    Adds the log level to the event dictionary under the key ``level``.
+
+:func:`~structlog.stdlib.add_log_level_number`:
+   Adds the log level number to the event dictionary under the key ``level_number``.
+   Log level numbers map to the log level names. The Python stdlib uses them for filtering logic. This adds the same numbers so users can leverage similar filtering. Compare::
+   
+      level in ("warning", "error", "critical")
+      level_number >= 30
+
+   The mapping of names to numbers is in :data:`~structlog.stdlib._NAME_TO_LEVEL`
 
 :class:`~structlog.stdlib.PositionalArgumentsFormatter`:
    This processes and formats positional arguments (if any) passed to log methods in the same way the ``logging`` module would do, e.g. ``logger.info("Hello, %s", name)``.

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -58,6 +58,9 @@ Processors
 :func:`~structlog.stdlib.add_logger_name`:
    Adds the name of the logger to the event dictionary under the key ``logger``.
 
+:func:`~structlog.stdlib.add_log_level_number`:
+   Adds the log level number to the event dictionary under the key ``level_number``.
+
 :func:`~structlog.stdlib.add_log_level`:
    Adds the log level to the event dictionary under the key ``level``.
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -330,6 +330,14 @@ def filter_by_level(logger, name, event_dict):
         raise DropEvent
 
 
+def add_log_level_number(logger, method_name, event_dict):
+    """
+    Adds the log level number to the event dict.
+    """
+    event_dict['level_number'] = _NAME_TO_LEVEL[method_name]
+    return event_dict
+
+
 def add_log_level(logger, method_name, event_dict):
     """
     Add the log level to the event dict.

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -330,14 +330,6 @@ def filter_by_level(logger, name, event_dict):
         raise DropEvent
 
 
-def add_log_level_number(logger, method_name, event_dict):
-    """
-    Adds the log level number to the event dict.
-    """
-    event_dict['level_number'] = _NAME_TO_LEVEL[method_name]
-    return event_dict
-
-
 def add_log_level(logger, method_name, event_dict):
     """
     Add the log level to the event dict.
@@ -347,6 +339,26 @@ def add_log_level(logger, method_name, event_dict):
         method_name = 'warning'
 
     event_dict['level'] = method_name
+    return event_dict
+
+
+def add_log_level_number(logger, method_name, event_dict):
+    """
+    Add the log level number to the event dict.
+
+    Log level numbers map to the log level names. The Python stdlib uses them
+    for filtering logic. This adds the same numbers so users can leverage
+    similar filtering. Compare::
+
+       level in ("warning", "error", "critical")
+       level_number >= 30
+
+    The mapping of names to numbers is in
+    :data:`~structlog.stdlib._NAME_TO_LEVEL`.
+
+    .. versionadded:: 18.2.0
+    """
+    event_dict["level_number"] = _NAME_TO_LEVEL[method_name]
     return event_dict
 
 

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 
 from six.moves import cStringIO as StringIO
+
 from structlog._loggers import (
     WRITE_LOCKS, PrintLogger, PrintLoggerFactory, ReturnLogger,
     ReturnLoggerFactory

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -18,9 +18,10 @@ from structlog.dev import ConsoleRenderer
 from structlog.exceptions import DropEvent
 from structlog.processors import JSONRenderer
 from structlog.stdlib import (
-    CRITICAL, WARN, BoundLogger, LoggerFactory, PositionalArgumentsFormatter,
-    ProcessorFormatter, _FixedFindCallerLogger, add_log_level, add_logger_name,
-    filter_by_level, render_to_log_kwargs
+    _NAME_TO_LEVEL, CRITICAL, WARN, BoundLogger, LoggerFactory,
+    PositionalArgumentsFormatter, ProcessorFormatter, _FixedFindCallerLogger,
+    add_log_level, add_log_level_number, add_logger_name, filter_by_level,
+    render_to_log_kwargs
 )
 
 from .additional_frame import additional_frame
@@ -280,6 +281,16 @@ class TestPositionalArgumentsFormatter(object):
         formatter = PositionalArgumentsFormatter()
 
         assert {} == formatter(None, None, {"positional_args": ()})
+
+
+class TestAddLogLevelNumber(object):
+    @pytest.mark.parametrize('level, number', _NAME_TO_LEVEL.items())
+    def test_log_level_number_added(self, level, number):
+        """
+        The log level number is added to the event dict.
+        """
+        event_dict = add_log_level_number(None, level, {})
+        assert number == event_dict['level_number']
 
 
 class TestAddLogLevel(object):

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -12,8 +12,8 @@ import pytest
 
 from pretend import call_recorder
 from six import PY3
-
 from six.moves import cStringIO as StringIO
+
 from structlog import ReturnLogger
 from structlog._config import _CONFIG
 from structlog.processors import KeyValueRenderer


### PR DESCRIPTION
When combing through logs, I find it's sometimes helpful to filter by a range of log levels. Currently this must be done by checking log level strings. This adds the number so it's easier to do such a check:

With only log levels:
`log_level in ("error", "warning", "critical")`

With log level numbers:
`log_level_number >= 30`