### PR TITLE
 Make default=_json_fallback_handlerer overridable in JSONRenderer.

### DIFF
--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -153,12 +153,12 @@ class JSONRenderer(object):
         ``serializer`` parameter.
     """
     def __init__(self, serializer=json.dumps, **dumps_kw):
+        dumps_kw.setdefault('default', _json_fallback_handler)
         self._dumps_kw = dumps_kw
         self._dumps = serializer
 
     def __call__(self, logger, name, event_dict):
-        return self._dumps(event_dict, default=_json_fallback_handler,
-                           **self._dumps_kw)
+        return self._dumps(event_dict, **self._dumps_kw)
 
 
 def _json_fallback_handler(obj):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -165,6 +165,15 @@ class TestJSONRenderer(object):
 
         assert {"a": 42} == jr(None, None, obj)
 
+    def test_custom_fallback(self):
+        """
+        A custom fallback handler can be used.
+        """
+        jr = JSONRenderer(default=lambda x: repr(x)[::-1])
+        d = {'date': datetime.date(1980, 3, 25)}
+
+        assert '{"date": ")52 ,3 ,0891(etad.emitetad"}' == jr(None, None, d)
+
     @pytest.mark.skipif(simplejson is None, reason="simplejson is missing.")
     def test_simplejson(self, event_dict):
         """


### PR DESCRIPTION
This addresses #77.  I don't think there are any documentation concerns here as JSONRenderer already relays extra keyword args to `dumps`.