### PR TITLE
Added brackets to list comprehension, fixing this exception:

### DIFF
--- a/src/structlog/_frames.py
+++ b/src/structlog/_frames.py
@@ -38,7 +38,7 @@ def _find_first_app_frame_and_name(additional_ignores=None):
     ignores = ["structlog"] + (additional_ignores or [])
     f = sys._getframe()
     name = f.f_globals.get("__name__") or "?"
-    while any([name.startswith(i) for i in ignores]):
+    while any(tuple(name.startswith(i) for i in ignores)):
         if f.f_back is None:
             name = "?"
             break

--- a/src/structlog/_frames.py
+++ b/src/structlog/_frames.py
@@ -38,7 +38,7 @@ def _find_first_app_frame_and_name(additional_ignores=None):
     ignores = ["structlog"] + (additional_ignores or [])
     f = sys._getframe()
     name = f.f_globals.get("__name__") or "?"
-    while any(name.startswith(i) for i in ignores):
+    while any([name.startswith(i) for i in ignores]):
         if f.f_back is None:
             name = "?"
             break


### PR DESCRIPTION
```
Exception ignored in: <generator object _find_first_app_frame_and_name.<locals>.<genexpr> at 0x10693ad00>
Traceback (most recent call last):
  File "/Users/ricardopinto/a_project/env/lib/python3.6/site-packages/structlog/_frames.py", line 42, in <genexpr>
    while any(name.startswith(i) for i in ignores):
SystemError: error return without exception set
```

From what I saw, `ignores` was `['structlog', 'logging']`, and `name` was `structlog._frames`.
Python version is 3.6.5, structlog is 18.1.0.