### PR TITLE
Make filter_by_level processor work with std lib logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- ``ProcessorFormatter`` doesn't crash anymore on stdlib logs when using ``stuctlog.stdlib.filter_by_level`` processor.
+  `#195 <https://github.com/hynek/structlog/pull/195>`_
 
 
 ----

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -461,7 +461,7 @@ class ProcessorFormatter(logging.Formatter):
             # would transform our dict into a str.
             ed = record.msg.copy()
         except AttributeError:
-            logger = None
+            logger = logging.getLogger(record.name)
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage(), "_record": record}
             record.args = ()
@@ -483,7 +483,7 @@ class ProcessorFormatter(logging.Formatter):
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).
             for proc in self.foreign_pre_chain or ():
-                ed = proc(None, meth_name, ed)
+                ed = proc(logger, meth_name, ed)
 
             del ed["_record"]
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -562,6 +562,24 @@ class TestProcessorFormatter(object):
             "e_chain_add_logger_name]\n",
         ) == capsys.readouterr()
 
+    def test_foreign_pre_chain_filter_by_level(self, configure_for_pf, capsys):
+        """
+        foreign_pre_chain works with filter_by_level processor.
+        """
+        configure_logging((filter_by_level,))
+        configure(
+            processors=[ProcessorFormatter.wrap_for_formatter],
+            logger_factory=LoggerFactory(),
+            wrapper_class=BoundLogger,
+        )
+
+        logging.getLogger().warning("foo")
+
+        assert (
+            "",
+            "foo [in test_foreign_pre_chain_filter_by_level]\n",
+        ) == capsys.readouterr()
+
     def test_foreign_chain_can_pass_dictionaries_without_excepting(
         self, configure_for_pf, capsys
     ):


### PR DESCRIPTION
When using `filter_by_level` processor with `ProcessorFormatter` it fails on std lib logs because of https://github.com/hynek/structlog/blob/c0aeab5f3ada09b7079d7ba7dc66314e1d8d2792/src/structlog/stdlib.py#L333 being called on `None`.