### PR TITLE
Add reference to django-structlog

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -156,10 +156,7 @@ Ideally as late as possible but *before* non-framework (i.e. your) code is execu
 If you use standard library's logging, it makes sense to configure them next to each other.
 
 **Django**
-   ``settings.py`` together with your other logging configuration.
-
-   For per-request loggers with bound request IDs, you can use `django-structlog <https://github.com/hynek/structlog/wiki/Third-party-Extensions/>`_ or write a simple middleware yourself.
-   See `this case study <https://github.com/hynek/structlog/issues/175>`_ for more concrete information.
+   See `Third-Party Extensions <https://github.com/hynek/structlog/wiki/Third-Party-Extensions/>`_ in the wiki.
 
 **Flask**
    See `Logging <http://flask.pocoo.org/docs/dev/logging/>`_.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,7 +158,7 @@ If you use standard library's logging, it makes sense to configure them next to 
 **Django**
    ``settings.py`` together with your other logging configuration.
 
-   For per-request loggers with bound request IDs, you can write a simple middleware.
+   For per-request loggers with bound request IDs, you can use `django-structlog <https://github.com/hynek/structlog/wiki/Third-party-Extensions/>`_ or write a simple middleware yourself.
    See `this case study <https://github.com/hynek/structlog/issues/175>`_ for more concrete information.
 
 **Flask**


### PR DESCRIPTION
I developped a pypi package to easily integrate structlog in django (it also includes a celery integration). I thought it would be helpful to add a reference to it in your documentation.

doc: https://django-structlog.readthedocs.io/en/latest/?badge=latest
pypi: https://pypi.org/project/django-structlog/
github: https://github.com/jrobichaud/django-structlog/
