### PR TITLE
event key parameter for ConsoleRender

### DIFF
--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -111,6 +111,8 @@ class ConsoleRenderer(object):
         must be a dict from level names (strings) to colorama styles. The
         default can be obtained by calling
         :meth:`ConsoleRenderer.get_default_level_styles`
+    :param string event_key_name: The name of the event key to be used out of
+        the event dict. the default value is set to 'event'.
 
     Requires the colorama_ package if *colors* is ``True``.
 
@@ -130,6 +132,7 @@ class ConsoleRenderer(object):
         force_colors=False,
         repr_native_str=False,
         level_styles=None,
+        event_key_name="event",
     ):
         if colors is True:
             if colorama is None:
@@ -152,6 +155,7 @@ class ConsoleRenderer(object):
 
         self._styles = styles
         self._pad_event = pad_event
+        self._event_key_name = event_key_name
 
         if level_styles is None:
             self._level_to_color = self.get_default_level_styles(colors)
@@ -198,7 +202,7 @@ class ConsoleRenderer(object):
                 + "] "
             )
 
-        event = event_dict.pop("event")
+        event = event_dict.pop(self._event_key_name)
         if event_dict:
             event = _pad(event, self._pad_event) + self._styles.reset + " "
         else:

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -32,6 +32,13 @@ def cr():
 
 
 @pytest.fixture
+def cre():
+    return dev.ConsoleRenderer(
+        colors=dev._has_colorama, event_key_name="message"
+    )
+
+
+@pytest.fixture
 def styles(cr):
     return cr._styles
 
@@ -68,6 +75,14 @@ class TestConsoleRenderer(object):
         Works with a plain event_dict with only the event.
         """
         rv = cr(None, None, {"event": "test"})
+
+        assert unpadded == rv
+
+    def test_plain_message(self, cre, styles, unpadded):
+        """
+        Works with a plain event_dict with only the event.
+        """
+        rv = cre(None, None, {"message": "test"})
 
         assert unpadded == rv
 


### PR DESCRIPTION
Add Named Argument for ConsoleRender incase user creates Processor to rename the `event` key to another name they can define what the new `key` to `Render` correctly into the `Console`