### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ matrix:
       dist: trusty
 
     # Prevent breakage by a new releases
-    - python: "3.7-dev"
-      env: TOXENV=py37-threads
-    - python: "3.7-dev"
-      env: TOXENV=py37-greenlets
+    - python: "3.8-dev"
+      env: TOXENV=py38-threads
+    - python: "3.8-dev"
+      env: TOXENV=py38-greenlets
 
     # docs
     - python: "3.7"
@@ -72,7 +72,7 @@ matrix:
       env: TOXENV=pypi-description
 
   allow_failures:
-    - python: "3.7-dev"
+    - python: "3.8-dev"
 
 
 install:

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -25,7 +25,7 @@ class _FixedFindCallerLogger(logging.Logger):
     Change the behavior of findCaller to cope with structlog's extra frames.
     """
 
-    def findCaller(self, stack_info=False):
+    def findCaller(self, stack_info=False, stacklevel=1):
         """
         Finds the first caller frame outside of structlog so that the caller
         info is populated for wrapping stdlib.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,{py27,py34,py35,py36,py37,pypy,pypy3}-threads,{py27,py37,pypy}-{greenlets,colorama,oldtwisted},docs,pypi-description,manifest,coverage-report
+envlist = lint,{py27,py34,py35,py36,py37,py38,pypy,pypy3}-threads,{py27,py37,pypy}-{greenlets,colorama,oldtwisted},docs,pypi-description,manifest,coverage-report
 isolated_build = True
 
 


### PR DESCRIPTION
Tests fail on Python 3.8:
```
structlog/stdlib.py:75: in warning
    return self._proxy_to_logger("warning", event, *args, **kw)
structlog/stdlib.py:118: in _proxy_to_logger
    return super(BoundLogger, self)._proxy_to_logger(
structlog/_base.py:192: in _proxy_to_logger
    return getattr(self._logger, method_name)(*args, **kw)
/usr/lib64/python3.8/logging/__init__.py:1457: in warning
    self._log(WARNING, msg, args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_FixedFindCallerLogger tests.test_stdlib (DEBUG)>, level = 30
msg = {'event': 'foo', 'level': 'warning'}, args = (), exc_info = None
extra = {'_logger': <_FixedFindCallerLogger tests.test_stdlib (DEBUG)>, '_name': 'warning'}
stack_info = False, stacklevel = 1

    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False,
             stacklevel=1):
        """
        Low-level logging routine which creates a LogRecord and then calls
        all the handlers of this logger to handle the record.
        """
        sinfo = None
        if _srcfile:
            #IronPython doesn't track Python frames, so findCaller raises an
            #exception on some versions of IronPython. We trap it here so that
            #IronPython can use logging.
            try:
>               fn, lno, func, sinfo = self.findCaller(stack_info, stacklevel)
E               TypeError: findCaller() takes from 1 to 2 positional arguments but 3 were given
```
This should fix it.