### PR TITLE
ConsoleRenderer: default to colorless when colorama is unavailable

### DIFF
--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -126,7 +126,7 @@ class ConsoleRenderer(object):
     def __init__(
         self,
         pad_event=_EVENT_WIDTH,
-        colors=True,
+        colors=_has_colorama,
         force_colors=False,
         repr_native_str=False,
         level_styles=None,

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -56,7 +56,7 @@ class TestConsoleRenderer(object):
         colorama is missing.
         """
         with pytest.raises(SystemError) as e:
-            dev.ConsoleRenderer()
+            dev.ConsoleRenderer(colors=True)
 
         assert (
             "ConsoleRenderer with `colors=True` requires the colorama package "


### PR DESCRIPTION
`colorama` isn't a direct dependency of `structlog`, and as such it might not be available. The console renderer should still work when it isn't, though.