### PR TITLE
Show the default processor list configuration in getting-started

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -38,7 +38,8 @@ Here, ``structlog`` takes full advantage of its hopefully useful default setting
   Thus, it's easy to add support for logging of your own objects\ [*]_.
 - If you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice :doc:`colors <development>`.
 
-It should be noted that even in most complex logging setups the example would still look just like that thanks to :ref:`configuration`. Using the defaults, as above, is equivalent to::
+It should be noted that even in most complex logging setups the example would still look just like that thanks to :ref:`configuration`.
+Using the defaults, as above, is equivalent to::
 
    import structlog
    structlog.configure(processors=[

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -42,12 +42,18 @@ It should be noted that even in most complex logging setups the example would st
 Using the defaults, as above, is equivalent to::
 
    import structlog
-   structlog.configure(processors=[
-       structlog.processors.StackInfoRenderer(),
-       structlog.processors.format_exc_info,
-       structlog.processors.TimeStamper(),
-       structlog.dev.ConsoleRenderer()
-   ])
+   structlog.configure(
+       processors=[
+           structlog.processors.StackInfoRenderer(),
+           structlog.processors.format_exc_info,
+           structlog.processors.TimeStamper(),
+           structlog.dev.ConsoleRenderer()
+       ],
+       wrapper_class=structlog.BoundLogger,
+       context_class=dict,
+       logger_factory=structlog.PrintLoggerFactory(),
+       cache_logger_on_first_use=False
+   )
    log = structlog.get_logger()
 
 .. note::

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -50,7 +50,7 @@ Using the defaults, as above, is equivalent to::
            structlog.dev.ConsoleRenderer()
        ],
        wrapper_class=structlog.BoundLogger,
-       context_class=dict,
+       context_class=dict,  # or OrderedDict if the runtime's dict is unordered (e.g. Python <3.6)
        logger_factory=structlog.PrintLoggerFactory(),
        cache_logger_on_first_use=False
    )

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -38,7 +38,16 @@ Here, ``structlog`` takes full advantage of its hopefully useful default setting
   Thus, it's easy to add support for logging of your own objects\ [*]_.
 - If you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice :doc:`colors <development>`.
 
-It should be noted that even in most complex logging setups the example would still look just like that thanks to :ref:`configuration`.
+It should be noted that even in most complex logging setups the example would still look just like that thanks to :ref:`configuration`. Using the defaults, as above, is equivalent to::
+
+   import structlog
+   structlog.configure(processors=[
+       structlog.processors.StackInfoRenderer(),
+       structlog.processors.format_exc_info,
+       structlog.processors.TimeStamper(),
+       structlog.dev.ConsoleRenderer()
+   ])
+   log = structlog.get_logger()
 
 .. note::
    For brevity and to enable doctests, all further examples in ``structlog``'s documentation use the more simplistic :class:`structlog.processors.KeyValueRenderer()` without timestamps.

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -20,6 +20,11 @@ from .dev import ConsoleRenderer, _has_colorama
 from .processors import StackInfoRenderer, TimeStamper, format_exc_info
 
 
+"""
+.. note::
+
+   Any changes to these defaults must be reflected in :doc:`getting-started`.
+"""
 _BUILTIN_DEFAULT_PROCESSORS = [
     StackInfoRenderer(),
     format_exc_info,


### PR DESCRIPTION
This facilitates making small and informed changes to the default processor list before delving into deeper docs or code. Mentioned at the end of #173, though it is not addressed to that bug.