### PR TITLE
Add logger argument to ProcessorFormatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Changes:
 - Added more pass-through properties to ``structlog.stdlib.BoundLogger``.
   To makes it easier to use it as a drop-in replacement for ``logging.Logger``.
   `#198 <https://github.com/hynek/structlog/issues/198>`_
+- `ProcessorFormatter` takes logger object as an optional keyword argument.
+  This fixes a bug when using ProcessorFormatter with
+  `stuctlog.stdlib.filter_by_level`.
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,9 +27,8 @@ Changes:
 - Added more pass-through properties to ``structlog.stdlib.BoundLogger``.
   To makes it easier to use it as a drop-in replacement for ``logging.Logger``.
   `#198 <https://github.com/hynek/structlog/issues/198>`_
-- `ProcessorFormatter` takes logger object as an optional keyword argument.
-  This fixes a bug when using ProcessorFormatter with
-  `stuctlog.stdlib.filter_by_level`.
+- ``ProcessorFormatter`` takes logger object as an optional keyword argument.
+  This fixes a bug when using ProcessorFormatter with ``stuctlog.stdlib.filter_by_level``.
 
 
 ----

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -465,14 +465,16 @@ class ProcessorFormatter(logging.Formatter):
         added to the ``event_dict`` and removed afterwards. Set this to
         ``True`` to keep it on the :class:`logging.LogRecord`. (default: False)
     :param bool keep_stack_info: Same as *keep_exc_info* except for Python 3's
-        ``stack_info``.
-    :param logger: Logger which we want to push through the structlog processor
-        chain.
+        ``stack_info``. (default: False)
+    :param logger: Logger which we want to push through the ``structlog``
+        processor chain. This parameter is necessary for some of the
+        processors like `filter_by_level`. (default: None)
 
     :rtype: str
 
     .. versionadded:: 17.1.0
     .. versionadded:: 17.2.0 *keep_exc_info* and *keep_stack_info*
+    .. versionadded:: 19.2.0 *logger*
     """
 
     def __init__(

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -466,6 +466,8 @@ class ProcessorFormatter(logging.Formatter):
         ``True`` to keep it on the :class:`logging.LogRecord`. (default: False)
     :param bool keep_stack_info: Same as *keep_exc_info* except for Python 3's
         ``stack_info``.
+    :param logger: Logger which we want to push through the structlog processor
+        chain.
 
     :rtype: str
 
@@ -479,6 +481,7 @@ class ProcessorFormatter(logging.Formatter):
         foreign_pre_chain=None,
         keep_exc_info=False,
         keep_stack_info=False,
+        logger=None,
         *args,
         **kwargs
     ):
@@ -489,6 +492,7 @@ class ProcessorFormatter(logging.Formatter):
         self.keep_exc_info = keep_exc_info
         # The and clause saves us checking for PY3 in the formatter.
         self.keep_stack_info = keep_stack_info and PY3
+        self.logger = logger
 
     def format(self, record):
         """
@@ -499,7 +503,7 @@ class ProcessorFormatter(logging.Formatter):
         record = logging.makeLogRecord(record.__dict__)
         try:
             # Both attached by wrap_for_formatter
-            logger = record._logger
+            logger = self.logger if self.logger is not None else record._logger
             meth_name = record._name
 
             # We need to copy because it's possible that the same record gets
@@ -507,7 +511,7 @@ class ProcessorFormatter(logging.Formatter):
             # would transform our dict into a str.
             ed = record.msg.copy()
         except AttributeError:
-            logger = None
+            logger = self.logger
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage(), "_record": record}
             record.args = ()
@@ -529,7 +533,7 @@ class ProcessorFormatter(logging.Formatter):
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).
             for proc in self.foreign_pre_chain or ():
-                ed = proc(None, meth_name, ed)
+                ed = proc(logger, meth_name, ed)
 
             del ed["_record"]
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -455,7 +455,7 @@ def configure_for_pf():
     reset_defaults()
 
 
-def configure_logging(pre_chain):
+def configure_logging(pre_chain, logger=None):
     """
     Configure logging to use ProcessorFormatter.
     """
@@ -469,6 +469,7 @@ def configure_logging(pre_chain):
                     "processor": ConsoleRenderer(colors=False),
                     "foreign_pre_chain": pre_chain,
                     "format": "%(message)s [in %(funcName)s]",
+                    "logger": logger,
                 }
             },
             "handlers": {
@@ -727,4 +728,23 @@ class TestProcessorFormatter(object):
         assert (
             "",
             "[warning  ] foo [in test_native]\n",
+        ) == capsys.readouterr()
+
+    def test_foreign_pre_chain_filter_by_level(self, configure_for_pf, capsys):
+        """
+        foreign_pre_chain works with filter_by_level processor.
+        """
+        logger = logging.getLogger()
+        configure_logging((filter_by_level,), logger=logger)
+        configure(
+            processors=[ProcessorFormatter.wrap_for_formatter],
+            logger_factory=LoggerFactory(),
+            wrapper_class=BoundLogger,
+        )
+
+        logger.warning("foo")
+
+        assert (
+            "",
+            "foo [in test_foreign_pre_chain_filter_by_level]\n",
         ) == capsys.readouterr()

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -455,7 +455,7 @@ def configure_for_pf():
     reset_defaults()
 
 
-def configure_logging(pre_chain):
+def configure_logging(pre_chain, logger=None):
     """
     Configure logging to use ProcessorFormatter.
     """
@@ -469,6 +469,7 @@ def configure_logging(pre_chain):
                     "processor": ConsoleRenderer(colors=False),
                     "foreign_pre_chain": pre_chain,
                     "format": "%(message)s [in %(funcName)s]",
+                    "logger": logger,
                 }
             },
             "handlers": {
@@ -728,3 +729,22 @@ class TestProcessorFormatter(object):
             "",
             "[warning  ] foo [in test_native]\n",
         ) == capsys.readouterr()
+
+    def test_foreign_pre_chain_filter_by_level(self, configure_for_pf, capsys):
+        """
+        foreign_pre_chain works with filter_by_level processor.
+        """
+        logger = logging.getLogger()
+        configure_logging((filter_by_level, ), logger=logger)
+        configure(
+            processors=[ProcessorFormatter.wrap_for_formatter],
+            logger_factory=LoggerFactory(),
+            wrapper_class=BoundLogger,
+        )
+
+        logger.warning("foo")
+
+        assert (
+                   "",
+                   "foo [in test_foreign_pre_chain_filter_by_level]\n",
+               ) == capsys.readouterr()

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -735,7 +735,7 @@ class TestProcessorFormatter(object):
         foreign_pre_chain works with filter_by_level processor.
         """
         logger = logging.getLogger()
-        configure_logging((filter_by_level, ), logger=logger)
+        configure_logging((filter_by_level,), logger=logger)
         configure(
             processors=[ProcessorFormatter.wrap_for_formatter],
             logger_factory=LoggerFactory(),
@@ -745,6 +745,6 @@ class TestProcessorFormatter(object):
         logger.warning("foo")
 
         assert (
-                   "",
-                   "foo [in test_foreign_pre_chain_filter_by_level]\n",
-               ) == capsys.readouterr()
+            "",
+            "foo [in test_foreign_pre_chain_filter_by_level]\n",
+        ) == capsys.readouterr()

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -455,7 +455,7 @@ def configure_for_pf():
     reset_defaults()
 
 
-def configure_logging(pre_chain, logger=None):
+def configure_logging(pre_chain):
     """
     Configure logging to use ProcessorFormatter.
     """
@@ -469,7 +469,6 @@ def configure_logging(pre_chain, logger=None):
                     "processor": ConsoleRenderer(colors=False),
                     "foreign_pre_chain": pre_chain,
                     "format": "%(message)s [in %(funcName)s]",
-                    "logger": logger,
                 }
             },
             "handlers": {
@@ -728,23 +727,4 @@ class TestProcessorFormatter(object):
         assert (
             "",
             "[warning  ] foo [in test_native]\n",
-        ) == capsys.readouterr()
-
-    def test_foreign_pre_chain_filter_by_level(self, configure_for_pf, capsys):
-        """
-        foreign_pre_chain works with filter_by_level processor.
-        """
-        logger = logging.getLogger()
-        configure_logging((filter_by_level,), logger=logger)
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
-
-        logger.warning("foo")
-
-        assert (
-            "",
-            "foo [in test_foreign_pre_chain_filter_by_level]\n",
         ) == capsys.readouterr()


### PR DESCRIPTION
`filter_by_level` processor needs logger object in order to find out what is the log level. Add `logger` as an argument to `ProcessorFormatter` and then pass it through the processor chain so `filter_by_level` can use it.

Related to #195 