### PR TITLE
A newer, better thread-local API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,7 +51,9 @@ Changes:
   So far, the configuration proxy, ``structlog.processor.TimeStamper``, ``structlog.BoundLogger``, ``structlog.PrintLogger`` and ``structlog.dev.ConsoleLogger`` have been made pickelable.
   Please report if you need any another class ported.
   `#126 <https://github.com/hynek/structlog/issues/126>`_
-
+- Added a new thread-local API that allows binding values to a thread-local context explicitly without affecting the default behavior of bind.
+  `#222 <https://github.com/hynek/structlog/issues/222>`_,
+  `#225 <https://github.com/hynek/structlog/issues/225>`_,
 
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,7 +51,7 @@ Changes:
   So far, the configuration proxy, ``structlog.processor.TimeStamper``, ``structlog.BoundLogger``, ``structlog.PrintLogger`` and ``structlog.dev.ConsoleLogger`` have been made pickelable.
   Please report if you need any another class ported.
   `#126 <https://github.com/hynek/structlog/issues/126>`_
-- Added a new thread-local API that allows binding values to a thread-local context explicitly without affecting the default behavior of bind.
+- Added a new thread-local API that allows binding values to a thread-local context explicitly without affecting the default behavior of ``bind()``.
   `#222 <https://github.com/hynek/structlog/issues/222>`_,
   `#225 <https://github.com/hynek/structlog/issues/225>`_,
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -77,6 +77,12 @@ API Reference
 
 .. automodule:: structlog.threadlocal
 
+.. autofunction:: merge_threadlocal_context
+
+.. autofunction:: clear_threadlocal
+
+.. autofunction:: bind_threadlocal
+
 .. autofunction:: wrap_dict
 
 .. autofunction:: tmp_bind(logger, **tmp_values)

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -41,10 +41,11 @@ These functions are :func:`structlog.threadlocal.merge_threadlocal_context`, :fu
 
 The general flow of using these functions is:
 
-- use :func:`structlog.configure` with :func:`structlog.threadlocal.merge_threadlocal_context` as your first processor
-- call :func:`structlog.threadlocal.clear_threadlocal` at the beginning of your request handler (or whenever you want to reset the thread-local context).
-- call :func:`structlog.threadlocal.bind_threadlocal` as an alternative to :func:`structlog.BoundLogger.bind` when you want to bind a particular variable to the thread-local context.
-- use ``structlog`` as normal. Loggers act as the always do, but the :func:`structlog.threadlocal.merge_threadlocal_context` processor ensures that any thread-local binds get included in all of your log messages.
+- Use :func:`structlog.configure` with :func:`structlog.threadlocal.merge_threadlocal_context` as your first processor.
+- Call :func:`structlog.threadlocal.clear_threadlocal` at the beginning of your request handler (or whenever you want to reset the thread-local context).
+- Call :func:`structlog.threadlocal.bind_threadlocal` as an alternative to :func:`structlog.BoundLogger.bind` when you want to bind a particular variable to the thread-local context.
+- Use ``structlog`` as normal.
+  Loggers act as the always do, but the :func:`structlog.threadlocal.merge_threadlocal_context` processor ensures that any thread-local binds get included in all of your log messages.
 
 .. testsetup:: merge_threadlocal
 

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -47,24 +47,21 @@ The general flow of using these functions is:
 - Use ``structlog`` as normal.
   Loggers act as the always do, but the :func:`structlog.threadlocal.merge_threadlocal_context` processor ensures that any thread-local binds get included in all of your log messages.
 
-.. testsetup:: merge_threadlocal
-
-   from structlog import PrintLogger, wrap_logger
-   from structlog.processors import KeyValueRenderer
-
-.. doctest:: merge_threadlocal
+.. doctest::
 
    >>> from structlog.threadlocal import (
    ...     bind_threadlocal,
    ...     clear_threadlocal,
    ...     merge_threadlocal_context,
    ... )
-   >>> # We pass merge_threadlocal_context to wrap_logger,
-   >>> # but you can also pass it to structlog.configure
-   >>> log = wrap_logger(
-   ...     PrintLogger(),
-   ...     processors=[merge_threadlocal_context, KeyValueRenderer()],
+   >>> from structlog import configure
+   >>> configure(
+   ...     processors=[
+   ...         merge_threadlocal_context,
+   ...         structlog.processors.KeyValueRenderer(),
+   ...     ]
    ... )
+   >>> log = structlog.get_logger()
    >>> # At the top of your request handler (or, ideally, some general
    >>> # middleware), clear the threadlocal context and bind some common
    >>> # values:

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -32,6 +32,7 @@ Sooner or later, global state and mutable data lead to unpleasant surprises.
 However, in the case of conventional web development, we realize that passing loggers around seems rather cumbersome, intrusive, and generally against the mainstream culture.
 And since it's more important that people actually *use* ``structlog`` than to be pure and snobby, ``structlog`` contains a couple of mechanisms to help here.
 
+
 The ``merge_threadlocal_context`` processor
 -------------------------------------------
 

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -30,7 +30,58 @@ If you are willing to do that, you should stick to it because `immutable state <
 Sooner or later, global state and mutable data lead to unpleasant surprises.
 
 However, in the case of conventional web development, we realize that passing loggers around seems rather cumbersome, intrusive, and generally against the mainstream culture.
-And since it's more important that people actually *use* ``structlog`` than to be pure and snobby, ``structlog`` contains a dirty but convenient trick: thread local context storage which you may already know from `Flask <http://flask.pocoo.org/docs/design/#thread-locals>`_:
+And since it's more important that people actually *use* ``structlog`` than to be pure and snobby, ``structlog`` contains a couple of mechanisms to help here.
+
+The ``merge_threadlocal_context`` processor
+-------------------------------------------
+
+``structlog`` provides a simple set of functions that allow explicitly binding certain fields to a global (thread-local) context.
+These functions are :func:`structlog.threadlocal.merge_threadlocal_context`, :func:`structlog.threadlocal.clear_threadlocal`, and :func:`structlog.threadlocal.bind_threadlocal`.
+
+The general flow of using these functions is:
+
+- use :func:`structlog.configure` with :func:`structlog.threadlocal.merge_threadlocal_context` as your first processor
+- call :func:`structlog.threadlocal.clear_threadlocal` at the beginning of your request handler (or whenever you want to reset the thread-local context).
+- call :func:`structlog.threadlocal.bind_threadlocal` as an alternative to :func:`structlog.BoundLogger.bind` when you want to bind a particular variable to the thread-local context.
+- use ``structlog`` as normal. Loggers act as the always do, but the :func:`structlog.threadlocal.merge_threadlocal_context` processor ensures that any thread-local binds get included in all of your log messages.
+
+.. testsetup:: merge_threadlocal
+
+   from structlog import PrintLogger, wrap_logger
+   from structlog.processors import KeyValueRenderer
+
+.. doctest:: merge_threadlocal
+
+   >>> from structlog.threadlocal import (
+   ...     bind_threadlocal,
+   ...     clear_threadlocal,
+   ...     merge_threadlocal_context,
+   ... )
+   >>> # We pass merge_threadlocal_context to wrap_logger,
+   >>> # but you can also pass it to structlog.configure
+   >>> log = wrap_logger(
+   ...     PrintLogger(),
+   ...     processors=[merge_threadlocal_context, KeyValueRenderer()],
+   ... )
+   >>> # At the top of your request handler (or, ideally, some general
+   >>> # middleware), clear the threadlocal context and bind some common
+   >>> # values:
+   >>> clear_threadlocal()
+   >>> bind_threadlocal(a=1)
+   >>> # Then use loggers as per normal
+   >>> # (perhaps by using structlog.get_logger() to create them).
+   >>> log.msg("hi")
+   a=1 event='hi'
+   >>> # And when we clear the threadlocal state again, it goes away.
+   >>> clear_threadlocal()
+   >>> log.msg("hi there")
+   event='hi there'
+
+
+Thread-local contexts
+---------------------
+
+``structlog`` also provides thread local context storage which you may already know from `Flask <http://flask.pocoo.org/docs/design/#thread-locals>`_:
 
 Thread local storage makes your logger's context global but *only within the current thread*\ [*]_.
 In the case of web frameworks this usually means that your context becomes global to the current request.

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -175,9 +175,7 @@ def merge_in_threadlocal(logger, method_name, event_dict):
     Use this as your first processor in :func:`structlog.configure` to ensure
     thread-local context is included in all log calls.
     """
-    if not hasattr(_CONTEXT, "context"):
-        _CONTEXT.context = {}
-    context = _CONTEXT.context.copy()
+    context = _get_context().copy()
     context.update(event_dict)
     return context
 
@@ -198,6 +196,12 @@ def bind_threadlocal(**kwargs):
     Use this instead of :func:`~structlog.BoundLogger.bind` when you want some
     context to be global (thread-local).
     """
-    if not hasattr(_CONTEXT, "context"):
+    _get_context().update(kwargs)
+
+
+def _get_context():
+    try:
+        return _CONTEXT.context
+    except AttributeError:
         _CONTEXT.context = {}
-    _CONTEXT.context.update(kwargs)
+        return _CONTEXT.context

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -170,7 +170,7 @@ _CONTEXT = threading.local()
 
 def merge_threadlocal_context(logger, method_name, event_dict):
     """
-    A structlog processor that merges in a global (thread-local) context.
+    A processor that merges in a global (thread-local) context.
 
     Use this as your first processor in :func:`structlog.configure` to ensure
     thread-local context is included in all log calls.
@@ -193,6 +193,7 @@ def clear_threadlocal():
 def bind_threadlocal(**kwargs):
     """
     Put keys and values into the thread-local context.
+
     Use this instead of :func:`~structlog.BoundLogger.bind` when you want some
     context to be global (thread-local).
     """

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -9,6 +9,7 @@ Primitives to keep context global but thread (and greenlet) local.
 from __future__ import absolute_import, division, print_function
 
 import contextlib
+import threading
 import uuid
 
 from structlog._config import BoundLoggerLazyProxy
@@ -164,7 +165,7 @@ class _ThreadLocalDictWrapper(object):
         return method
 
 
-_CONTEXT = ThreadLocal()
+_CONTEXT = threading.local()
 
 
 def merge_in_threadlocal(logger, method_name, event_dict):
@@ -174,7 +175,7 @@ def merge_in_threadlocal(logger, method_name, event_dict):
     Use this as your first processor in :func:`structlog.configure` to ensure
     thread-local context is included in all log calls.
     """
-    if not hasattr(_CONTEXT, 'context'):
+    if not hasattr(_CONTEXT, "context"):
         _CONTEXT.context = {}
     context = _CONTEXT.context.copy()
     context.update(event_dict)
@@ -197,6 +198,6 @@ def bind_threadlocal(**kwargs):
     Use this instead of :func:`~structlog.BoundLogger.bind` when you want some
     context to be global (thread-local).
     """
-    if not hasattr(_CONTEXT, 'context'):
+    if not hasattr(_CONTEXT, "context"):
         _CONTEXT.context = {}
     _CONTEXT.context.update(kwargs)

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -168,7 +168,7 @@ class _ThreadLocalDictWrapper(object):
 _CONTEXT = threading.local()
 
 
-def merge_in_threadlocal(logger, method_name, event_dict):
+def merge_threadlocal_context(logger, method_name, event_dict):
     """
     A structlog processor that merges in a global (thread-local) context.
 

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -15,11 +15,11 @@ from structlog._config import wrap_logger
 from structlog._loggers import ReturnLogger
 from structlog.threadlocal import (
     as_immutable,
+    bind_threadlocal,
+    clear_threadlocal,
+    merge_in_threadlocal,
     tmp_bind,
     wrap_dict,
-    merge_in_threadlocal,
-    clear_threadlocal,
-    bind_threadlocal,
 )
 
 

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -13,7 +13,14 @@ import pytest
 from structlog._base import BoundLoggerBase
 from structlog._config import wrap_logger
 from structlog._loggers import ReturnLogger
-from structlog.threadlocal import as_immutable, tmp_bind, wrap_dict
+from structlog.threadlocal import (
+    as_immutable,
+    tmp_bind,
+    wrap_dict,
+    merge_in_threadlocal,
+    clear_threadlocal,
+    bind_threadlocal,
+)
 
 
 try:
@@ -262,3 +269,26 @@ class TestThreadLocalDict(object):
         The context of a new wrapped class is empty.
         """
         assert 0 == len(D())
+
+
+class TestNewThreadLocal(object):
+    def test_bind_and_merge(self):
+        bind_threadlocal(a=1)
+        assert merge_in_threadlocal(None, None, {"b": 2}) == {"a": 1, "b": 2}
+
+    def test_clear(self):
+        bind_threadlocal(a=1)
+        clear_threadlocal()
+        assert merge_in_threadlocal(None, None, {"b": 2}) == {"b": 2}
+
+    def test_merge_works_without_bind(self):
+        assert merge_in_threadlocal(None, None, {"b": 2}) == {"b": 2}
+
+    def test_multiple_binds(self):
+        bind_threadlocal(a=1, b=2)
+        bind_threadlocal(c=3)
+        assert merge_in_threadlocal(None, None, {"b": 2}) == {
+            "a": 1,
+            "b": 2,
+            "c": 3,
+        }

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -273,20 +273,36 @@ class TestThreadLocalDict(object):
 
 class TestNewThreadLocal(object):
     def test_bind_and_merge(self):
+        """
+        Binding a variable causes it to be included in the result of
+        merge_threadlocal_context.
+        """
         bind_threadlocal(a=1)
         assert {"a": 1, "b": 2} == merge_threadlocal_context(
             None, None, {"b": 2}
         )
 
     def test_clear(self):
+        """
+        The thread-local context can be cleared, causing any previously bound
+        variables to not be included in merge_threadlocal_context's result.
+        """
         bind_threadlocal(a=1)
         clear_threadlocal()
         assert {"b": 2} == merge_threadlocal_context(None, None, {"b": 2})
 
     def test_merge_works_without_bind(self):
+        """
+        merge_threadlocal_context returns values as normal even when there has
+        been no previous calls to bind_threadlocal.
+        """
         assert {"b": 2} == merge_threadlocal_context(None, None, {"b": 2})
 
     def test_multiple_binds(self):
+        """
+        Multiple calls to bind_threadlocal accumulate values instead of
+        replacing them.
+        """
         bind_threadlocal(a=1, b=2)
         bind_threadlocal(c=3)
         assert {"a": 1, "b": 2, "c": 3} == merge_threadlocal_context(

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -17,7 +17,7 @@ from structlog.threadlocal import (
     as_immutable,
     bind_threadlocal,
     clear_threadlocal,
-    merge_in_threadlocal,
+    merge_threadlocal_context,
     tmp_bind,
     wrap_dict,
 )
@@ -274,21 +274,21 @@ class TestThreadLocalDict(object):
 class TestNewThreadLocal(object):
     def test_bind_and_merge(self):
         bind_threadlocal(a=1)
-        assert merge_in_threadlocal(None, None, {"b": 2}) == {"a": 1, "b": 2}
+        assert {"a": 1, "b": 2} == merge_threadlocal_context(
+            None, None, {"b": 2}
+        )
 
     def test_clear(self):
         bind_threadlocal(a=1)
         clear_threadlocal()
-        assert merge_in_threadlocal(None, None, {"b": 2}) == {"b": 2}
+        assert {"b": 2} == merge_threadlocal_context(None, None, {"b": 2})
 
     def test_merge_works_without_bind(self):
-        assert merge_in_threadlocal(None, None, {"b": 2}) == {"b": 2}
+        assert {"b": 2} == merge_threadlocal_context(None, None, {"b": 2})
 
     def test_multiple_binds(self):
         bind_threadlocal(a=1, b=2)
         bind_threadlocal(c=3)
-        assert merge_in_threadlocal(None, None, {"b": 2}) == {
-            "a": 1,
-            "b": 2,
-            "c": 3,
-        }
+        assert {"a": 1, "b": 2, "c": 3} == merge_threadlocal_context(
+            None, None, {"b": 2}
+        )


### PR DESCRIPTION
Fixes #222 

caveat: I didn't duplicate the greenlet support because it turns out greenlet.getcurrent() doesn't seem to return separate objects for different OS-level Python threads. That means that if you somehow have `greenlet` in your dependency tree, the existing thread-local stuff will just straight up not work.

If someone cares I'm sure it'd be possible to implement something that uses greenlets and threadlocal in a way that ensures that you get distinct values in different greenlets AND distinct values in different python threads.