### PR TITLE
Allow foreign_pre_chain To Read Foreign Log Args

### DIFF
--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -469,12 +469,14 @@ class ProcessorFormatter(logging.Formatter):
     :param logger: Logger which we want to push through the ``structlog``
         processor chain. This parameter is necessary for some of the
         processors like `filter_by_level`. (default: None)
-
+    :param bool pass_foreign_args: If `True`, pass a foreign log record's
+        `args` to the event_dict under `positional_args` key. (default: False)
     :rtype: str
 
     .. versionadded:: 17.1.0
     .. versionadded:: 17.2.0 *keep_exc_info* and *keep_stack_info*
     .. versionadded:: 19.2.0 *logger*
+    .. versionadded:: 19.2.0 *pass_foreign_args*
     """
 
     def __init__(

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -486,6 +486,7 @@ class ProcessorFormatter(logging.Formatter):
         keep_exc_info=False,
         keep_stack_info=False,
         logger=None,
+        pass_foreign_args=False,
         *args,
         **kwargs
     ):
@@ -497,6 +498,7 @@ class ProcessorFormatter(logging.Formatter):
         # The and clause saves us checking for PY3 in the formatter.
         self.keep_stack_info = keep_stack_info and PY3
         self.logger = logger
+        self.pass_foreign_args = pass_foreign_args
 
     def format(self, record):
         """
@@ -518,6 +520,10 @@ class ProcessorFormatter(logging.Formatter):
             logger = self.logger
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage(), "_record": record}
+
+            if self.pass_foreign_args:
+                ed["positional_args"] = record.args
+
             record.args = ()
 
             # Add stack-related attributes to event_dict and unset them

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -455,7 +455,7 @@ def configure_for_pf():
     reset_defaults()
 
 
-def configure_logging(pre_chain, logger=None):
+def configure_logging(pre_chain, logger=None, pass_foreign_args=False):
     """
     Configure logging to use ProcessorFormatter.
     """
@@ -470,6 +470,7 @@ def configure_logging(pre_chain, logger=None):
                     "foreign_pre_chain": pre_chain,
                     "format": "%(message)s [in %(funcName)s]",
                     "logger": logger,
+                    "pass_foreign_args": pass_foreign_args,
                 }
             },
             "handlers": {
@@ -526,6 +527,29 @@ class TestProcessorFormatter(object):
             "",
             "hello world. [in test_clears_args]\n",
         ) == capsys.readouterr()
+
+    def test_pass_foreign_args_true_sets_positional_args_key(
+        self, configure_for_pf, capsys
+    ):
+        """
+        Test that when `pass_foreign_args` is `True` we set the
+        `positional_args` key in the `event_dict` before clearing args.
+        """
+        test_processor = call_recorder(lambda l, m, event_dict: event_dict)
+        configure_logging((test_processor,), pass_foreign_args=True)
+        configure(
+            processors=[ProcessorFormatter.wrap_for_formatter],
+            logger_factory=LoggerFactory(),
+            wrapper_class=BoundLogger,
+        )
+
+        positional_args = {"foo": "bar"}
+        logging.getLogger().info("okay %(foo)s", positional_args)
+
+        event_dict = test_processor.calls[0].args[2]
+
+        assert "positional_args" in event_dict
+        assert positional_args == event_dict["positional_args"]
 
     def test_log_dict(self, configure_for_pf, capsys):
         """


### PR DESCRIPTION
Resolves #227 

When migrating a project from stdlib logging to `structlog`, an easy first step is to use `ProcessorFormatter` with processors defined in `foreign_pre_chain`. These will run on every stdlib log message sent into the formatter.

However, right now there is no way to access a LogRecord's `args` in the `foreign_pre_chain` processors because they are stripped before the record is passed to the processors.

This PR introduces a `pass_foreign_args` kwarg to `ProcessorFormatter`. When set to `True`, it will inject a foreign log record's `args` attribute into the `event_dict` under the `positional_args` key before stripping them from the record.