### PR TITLE
Make pip install -e . work on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,3 +126,26 @@ jobs:
           CODECOV_TOKEN: $(codecov.token)
         displayName: Report Coverage
         condition: succeeded()
+
+
+  # Make sure contributors can use Windows.
+  - job: 'Windows'
+    pool:
+      vmImage: 'windows-latest'
+    strategy:
+      matrix:
+        py38:
+          python.version: '3.8'
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(python.version)'
+          architecture: 'x64'
+        displayName: Use cached Python $(python.version) for tests.
+
+      - script: python -m pip install -e .[dev]
+        displayName: Install package in dev mode.
+
+      - script: python -m pytest
+        displayName: Run tests.

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ LONG = (
     + "Release Information\n"
     + "===================\n\n"
     + re.search(
-        r"(\d+.\d.\d \(.*?\)\n.*?)\n\n\n----\n\n\n",
+        r"(\d+.\d.\d \(.*?\)\r?\n.*?)\r?\n\r?\n\r?\n----\r?\n\r?\n\r?\n",
         read("CHANGELOG.rst"),
         re.S,
     ).group(1)


### PR DESCRIPTION
This hopefully fixes `pip install -e .` on Windows as mentioned in #242.