### PR TITLE
Implement async bound loggers for stdlib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       exclude: docs/code_examples
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,9 @@ Changes:
   `#266 <https://github.com/hynek/structlog/issues/266>`_,
 - ``structlog.PrintLogger`` now supports ``copy.deepcopy()``.
   `#268 <https://github.com/hynek/structlog/issues/268>`_
-- Added ``structlog.testing.CapturingLogger`` for more unittesting goodness.
+- Added ``structlog.testing.CapturingLogger`` for more unit testing goodness.
+- Added ``structlog.stdlib.AsyncBoundLogger`` that executes logging calls in a thread executor and therefore doesn't block.
+  `#245 <https://github.com/hynek/structlog/pull/245>`_
 
 
 ----

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@
 # repository for complete details.
 
 
+import logging
 import sys
 
 from io import StringIO
@@ -10,6 +11,7 @@ from io import StringIO
 import pytest
 
 from structlog._log_levels import _NAME_TO_LEVEL
+from structlog.testing import CapturingLogger
 
 
 try:
@@ -17,11 +19,25 @@ try:
 except ImportError:
     twisted = None
 
+LOGGER = logging.getLogger()
 
-@pytest.fixture
-def sio():
+
+@pytest.fixture(autouse=True)
+def _ensure_logging_framework_not_altered():
     """
-    A StringIO instance.
+    Prevents 'ValueError: I/O operation on closed file.' errors.
+    """
+    before_handlers = list(LOGGER.handlers)
+
+    yield
+
+    LOGGER.handlers = before_handlers
+
+
+@pytest.fixture(name="sio")
+def _sio():
+    """
+    A new StringIO instance.
     """
     return StringIO()
 
@@ -43,8 +59,13 @@ def event_dict():
     name="stdlib_log_method",
     params=[m for m in _NAME_TO_LEVEL if m != "notset"],
 )
-def fixture_stdlib_log_methods(request):
+def _stdlib_log_methods(request):
     return request.param
+
+
+@pytest.fixture(name="cl")
+def _cl():
+    return CapturingLogger()
 
 
 collect_ignore = []

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -237,6 +237,9 @@ API Reference
 .. autoclass:: BoundLogger
    :members: bind, unbind, new, debug, info, warning, warn, error, critical, exception, log
 
+.. autoclass:: AsyncBoundLogger
+   :members: bind, unbind, new, debug, info, warning, warn, error, critical, exception, log
+
 .. autoclass:: LoggerFactory
    :members: __call__
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -235,10 +235,9 @@ API Reference
 .. autofunction:: get_logger
 
 .. autoclass:: BoundLogger
-   :members: bind, unbind, new, debug, info, warning, warn, error, critical, exception, log
+   :members: bind, unbind, try_unbind, new, debug, info, warning, warn, error, critical, exception, log
 
 .. autoclass:: AsyncBoundLogger
-   :members: bind, unbind, new, debug, info, warning, warn, error, critical, exception, log
 
 .. autoclass:: LoggerFactory
    :members: __call__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ nitpick_ignore = [
     ("py:class", "TextIO"),
     ("py:class", "structlog._base.BoundLoggerBase"),
     ("py:class", "structlog.dev._Styles"),
+    ("py:obj", "sync_bl"),
 ]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -56,7 +56,7 @@ For that use case ``structlog`` comes with `structlog.stdlib.AsyncBoundLogger` t
 
 This means an increased computational cost per log entry but your application will never block because of logging.
 
-To use it, :doc:`configure <configuration>` structlog to use `AsyncBoundLogger` as ``wrapper_class``.
+To use it, :doc:`configure <configuration>` ``structlog`` to use `AsyncBoundLogger` as ``wrapper_class``.
 
 
 Processors

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -56,7 +56,7 @@ For that use case ``structlog`` comes with `structlog.stdlib.AsyncBoundLogger` t
 
 This means an increased computational cost per log entry but your application will never block because of logging.
 
-To use it, simply replace all instances of `structlog.stdlib.BoundLogger` with `AsyncBoundLogger` in all calls to `structlog.configure`.
+To use it, :doc:`configure <configuration>` structlog to use `AsyncBoundLogger` as ``wrapper_class``.
 
 
 Processors

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -48,6 +48,17 @@ Please note though, that it will neither configure nor verify your configuration
 It will call `structlog.get_logger()` just like if you would've called it -- the only difference are the type hints.
 
 
+``asyncio``
+^^^^^^^^^^^
+
+For ``asyncio`` applications, you may not want your whole application to block while your processor chain is formatting your log entries.
+For that use case ``structlog`` comes with `structlog.stdlib.AsyncBoundLogger` that will do all processing in a thread pool executor.
+
+This means an increased computational cost per log entry but your application will never block because of logging.
+
+To use it, simply replace all instances of `structlog.stdlib.BoundLogger` with `AsyncBoundLogger` in all calls to `structlog.configure`.
+
+
 Processors
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS_REQUIRE = {
         "coverage[toml]",
         "freezegun>=0.2.8",
         "pretend",
-        "pytest-asyncio; python_version>='3.7'",
+        "pytest-asyncio",
         "pytest-randomly",
         "pytest>=6.0",
         "simplejson",

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -14,30 +14,42 @@ import logging
 import sys
 
 from functools import partial
-from typing import Any, Dict, List, Optional, Sequence, Tuple
-from typing import Any, Callable, List, Mapping, Sequence
-from typing import Any, Callable, List, Mapping, Sequence
-from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from ._base import BoundLoggerBase
 from ._config import get_logger as _generic_get_logger
 from ._frames import _find_first_app_frame_and_name, _format_stack
 from ._log_levels import _LEVEL_TO_NAME, _NAME_TO_LEVEL, add_log_level
 from .exceptions import DropEvent
-from .types import EventDict, ExcInfo, Processor, WrappedLogger
+from .types import Context, EventDict, ExcInfo, Processor, WrappedLogger
+
+
+try:
+    from . import contextvars
+except ImportError:
+    contextvars = None  # type: ignore
 
 
 __all__ = [
-    "BoundLogger",
-    "get_logger",
-    "LoggerFactory",
-    "PositionalArgumentsFormatter",
-    "filter_by_level",
     "add_log_level_number",
     "add_log_level",
     "add_logger_name",
-    "render_to_log_kwargs",
+    "BoundLogger",
+    "filter_by_level",
+    "get_logger",
+    "LoggerFactory",
+    "PositionalArgumentsFormatter",
     "ProcessorFormatter",
+    "render_to_log_kwargs",
 ]
 
 
@@ -346,15 +358,16 @@ def get_logger(*args: Any, **initial_values: Any) -> BoundLogger:
 
 class AsyncBoundLogger:
     """
-    Wrap a `BoundLogger` and run its logging methods asynchronously in a thread
+    Wraps a `BoundLogger` & exposes its logging methods as ``async`` versions.
+
+    Instead of blocking the program, they are run asynchronously in a thread
     pool executor.
 
     This means more computational overhead per log call. But it also means that
     the processor chain (e.g. JSON serialization) and I/O won't block your
     whole application.
 
-    .. warning:
-        Since the processor pipeline runs in a separate thread,
+    .. warning: Since the processor pipeline runs in a separate thread,
         `structlog.contextvars.merge_contextvars` does **nothing** and should
         be removed from you processor chain.
 
@@ -363,13 +376,15 @@ class AsyncBoundLogger:
 
     Only available for Python 3.7 and later.
 
-    :ivar sync_bl: The wrapped synchronous logger. It is useful to be able to
-       log synchronously occasionally.
+    :ivar structlog.stdlib.BoundLogger sync_bl: The wrapped synchronous logger.
+       It is useful to be able to log synchronously occasionally.
 
     .. versionadded:: 20.2.0
     """
 
     __slots__ = ["sync_bl", "_loop"]
+
+    sync_bl: BoundLogger
 
     _executor = None
     _bound_logger_factory = BoundLogger
@@ -377,29 +392,73 @@ class AsyncBoundLogger:
     def __init__(
         self,
         logger: logging.Logger,
-        processors: List[Callable],
-        context: Mapping,
+        processors: Iterable[Processor],
+        context: Context,
+        *,
+        # Only as an optimization for binding!
+        _sync_bl: Any = None,  # *vroom vroom* over purity.
+        _loop: Any = None,
     ):
+        if _sync_bl:
+            self.sync_bl = _sync_bl
+            self._loop = _loop
+
+            return
+
         self.sync_bl = self._bound_logger_factory(
             logger=logger, processors=processors, context=context
         )
         self._loop = asyncio.get_running_loop()
 
+    @property
+    def _context(self) -> Context:
+        return self.sync_bl._context
+
     def bind(self, **new_values: Any) -> "AsyncBoundLogger":
-        self.sync_bl = self.sync_bl.bind(**new_values)
-        return self
+        return AsyncBoundLogger(
+            # logger, processors and context are within sync_bl. These
+            # arguments are ignored if _sync_bl is passsed. *vroom vroom* over
+            # purity.
+            logger=None,  # type: ignore
+            processors=(),
+            context={},
+            _sync_bl=self.sync_bl.bind(**new_values),
+            _loop=self._loop,
+        )
 
     def new(self, **new_values: Any) -> "AsyncBoundLogger":
-        self.sync_bl = self.sync_bl.new(**new_values)
-        return self
+        return AsyncBoundLogger(
+            # c.f. comment in bind
+            logger=None,  # type: ignore
+            processors=(),
+            context={},
+            _sync_bl=self.sync_bl.new(**new_values),
+            _loop=self._loop,
+        )
 
-    def unbind(self, *keys: Sequence[str]) -> "AsyncBoundLogger":
-        self.sync_bl = self.sync_bl.try_unbind(*keys)
-        return self
+    def unbind(self, *keys: str) -> "AsyncBoundLogger":
+        return AsyncBoundLogger(
+            # c.f. comment in bind
+            logger=None,  # type: ignore
+            processors=(),
+            context={},
+            _sync_bl=self.sync_bl.unbind(*keys),
+            _loop=self._loop,
+        )
+
+    def try_unbind(self, *keys: str) -> "AsyncBoundLogger":
+        return AsyncBoundLogger(
+            # c.f. comment in bind
+            logger=None,  # type: ignore
+            processors=(),
+            context={},
+            _sync_bl=self.sync_bl.try_unbind(*keys),
+            _loop=self._loop,
+        )
 
     async def _dispatch_to_sync(
         self,
-        meth: Callable,
+        meth: Callable[..., Any],
         event: str,
         args: Tuple[Any, ...],
         kw: Dict[str, Any],
@@ -409,6 +468,7 @@ class AsyncBoundLogger:
         """
         ctx = contextvars._get_context().copy()
         ctx.update(kw)
+
         await self._loop.run_in_executor(
             self._executor, partial(meth, event, *args, **ctx)
         )
@@ -438,6 +498,7 @@ class AsyncBoundLogger:
         ei = kw.pop("exc_info", None)
         if ei is None and kw.get("exception") is None:
             ei = sys.exc_info()
+
         kw["exc_info"] = ei
 
         await self._dispatch_to_sync(self.sync_bl.exception, event, args, kw)

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -342,12 +342,17 @@ def get_logger(*args: Any, **initial_values: Any) -> BoundLogger:
 
 class AsyncBoundLogger:
     """
-    Wraps a `BoundLogger` and runs its logging methods asynchronously in
-    a thread executor.
+    Wrap a `BoundLogger` and run its logging methods asynchronously in a thread
+    executor.
+
+    .. note::
+        This means more computational overhead per log call. But it also means
+        that the processor chain (e.g. JSON serialization) and I/O won't block
+        your whole application.
 
     Only available for Python 3.7 and later.
 
-    .. versionadded:: 20.2
+    .. versionadded:: 20.2.0
     """
 
     __slots__ = ["sync_bl", "_loop"]

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -346,15 +346,17 @@ class AsyncBoundLogger:
     a thread executor.
 
     Only available for Python 3.7 and later.
+
+    .. versionadded:: 20.2
     """
 
     __slots__ = ["sync_bl", "_loop"]
 
-    executor = None
-    bound_logger_factory = BoundLogger
+    _executor = None
+    _bound_logger_factory = BoundLogger
 
     def __init__(self, *args, **kw):
-        self.sync_bl = self.bound_logger_factory(*args, **kw)
+        self.sync_bl = self._bound_logger_factory(*args, **kw)
         self._loop = asyncio.get_running_loop()
 
     def bind(self, **new_values) -> "AsyncBoundLogger":
@@ -371,41 +373,42 @@ class AsyncBoundLogger:
 
     async def debug(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.debug, event, *args, **kw)
+            self._executor, partial(self.sync_bl.debug, event, *args, **kw)
         )
 
     async def info(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.info, event, *args, **kw)
+            self._executor, partial(self.sync_bl.info, event, *args, **kw)
         )
 
     async def warning(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.warning, event, *args, **kw)
+            self._executor, partial(self.sync_bl.warning, event, *args, **kw)
         )
 
     warn = warning
 
     async def error(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.error, event, *args, **kw)
+            self._executor, partial(self.sync_bl.error, event, *args, **kw)
         )
 
     async def critical(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.critical, event, *args, **kw)
+            self._executor, partial(self.sync_bl.critical, event, *args, **kw)
         )
 
     fatal = critical
 
     async def exception(self, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.exception, event, *args, **kw)
+            self._executor, partial(self.sync_bl.exception, event, *args, **kw)
         )
 
     async def log(self, level, event, *args, **kw):
         return await self._loop.run_in_executor(
-            self.executor, partial(self.sync_bl.log, level, event, *args, **kw)
+            self._executor,
+            partial(self.sync_bl.log, level, event, *args, **kw),
         )
 
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -16,6 +16,8 @@ import sys
 from functools import partial
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 from typing import Any, Callable, List, Mapping, Sequence
+from typing import Any, Callable, List, Mapping, Sequence
+from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple
 
 from ._base import BoundLoggerBase
 from ._config import get_logger as _generic_get_logger
@@ -347,12 +349,22 @@ class AsyncBoundLogger:
     Wrap a `BoundLogger` and run its logging methods asynchronously in a thread
     pool executor.
 
-    .. note::
-       This means more computational overhead per log call. But it also means
-       that the processor chain (e.g. JSON serialization) and I/O won't block
-       your whole application.
+    This means more computational overhead per log call. But it also means that
+    the processor chain (e.g. JSON serialization) and I/O won't block your
+    whole application.
+
+    .. warning:
+        Since the processor pipeline runs in a separate thread,
+        `structlog.contextvars.merge_contextvars` does **nothing** and should
+        be removed from you processor chain.
+
+        Instead it's merged within **this logger** before handing off log
+        processing to the thread.
 
     Only available for Python 3.7 and later.
+
+    :ivar sync_bl: The wrapped synchronous logger. It is useful to be able to
+       log synchronously occasionally.
 
     .. versionadded:: 20.2.0
     """
@@ -385,32 +397,38 @@ class AsyncBoundLogger:
         self.sync_bl = self.sync_bl.try_unbind(*keys)
         return self
 
-    async def debug(self, event: str, *args: Any, **kw: Any) -> None:
+    async def _dispatch_to_sync(
+        self,
+        meth: Callable,
+        event: str,
+        args: Tuple[Any, ...],
+        kw: Dict[str, Any],
+    ) -> None:
+        """
+        Merge contextvars and log using the sync logger in a thread pool.
+        """
+        ctx = contextvars._get_context().copy()
+        ctx.update(kw)
         await self._loop.run_in_executor(
-            self._executor, partial(self.sync_bl.debug, event, *args, **kw)
+            self._executor, partial(meth, event, *args, **ctx)
         )
+
+    async def debug(self, event: str, *args: Any, **kw: Any) -> None:
+        await self._dispatch_to_sync(self.sync_bl.debug, event, args, kw)
 
     async def info(self, event: str, *args: Any, **kw: Any) -> None:
-        await self._loop.run_in_executor(
-            self._executor, partial(self.sync_bl.info, event, *args, **kw)
-        )
+        await self._dispatch_to_sync(self.sync_bl.info, event, args, kw)
 
     async def warning(self, event: str, *args: Any, **kw: Any) -> None:
-        await self._loop.run_in_executor(
-            self._executor, partial(self.sync_bl.warning, event, *args, **kw)
-        )
+        await self._dispatch_to_sync(self.sync_bl.warning, event, args, kw)
 
     warn = warning
 
     async def error(self, event: str, *args: Any, **kw: Any) -> None:
-        await self._loop.run_in_executor(
-            self._executor, partial(self.sync_bl.error, event, *args, **kw)
-        )
+        await self._dispatch_to_sync(self.sync_bl.error, event, args, kw)
 
     async def critical(self, event: str, *args: Any, **kw: Any) -> None:
-        await self._loop.run_in_executor(
-            self._executor, partial(self.sync_bl.critical, event, *args, **kw)
-        )
+        await self._dispatch_to_sync(self.sync_bl.critical, event, args, kw)
 
     fatal = critical
 
@@ -420,16 +438,13 @@ class AsyncBoundLogger:
         ei = kw.pop("exc_info", None)
         if ei is None and kw.get("exception") is None:
             ei = sys.exc_info()
+        kw["exc_info"] = ei
 
-        await self._loop.run_in_executor(
-            self._executor,
-            partial(self.sync_bl.exception, event, *args, exc_info=ei, **kw),
-        )
+        await self._dispatch_to_sync(self.sync_bl.exception, event, args, kw)
 
     async def log(self, level: Any, event: str, *args: Any, **kw: Any) -> None:
-        await self._loop.run_in_executor(
-            self._executor,
-            partial(self.sync_bl.log, level, event, *args, **kw),
+        await self._dispatch_to_sync(
+            partial(self.sync_bl.log, level), event, args, kw
         )
 
 

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -7,7 +7,7 @@ import copy
 import pickle
 import sys
 
-from io import BytesIO, StringIO
+from io import BytesIO
 
 import pytest
 
@@ -53,12 +53,10 @@ class TestPrintLogger:
         """
         assert repr(PrintLogger()).startswith("<PrintLogger(file=")
 
-    def test_lock(self):
+    def test_lock(self, sio):
         """
         Creating a logger adds a lock to WRITE_LOCKS.
         """
-        sio = StringIO()
-
         assert sio not in WRITE_LOCKS
 
         PrintLogger(sio)
@@ -66,12 +64,10 @@ class TestPrintLogger:
         assert sio in WRITE_LOCKS
 
     @pytest.mark.parametrize("method", stdlib_log_methods)
-    def test_stdlib_methods_support(self, method):
+    def test_stdlib_methods_support(self, method, sio):
         """
         PrintLogger implements methods of stdlib loggers.
         """
-        sio = StringIO()
-
         getattr(PrintLogger(sio), method)("hello")
 
         assert "hello" in sio.getvalue()
@@ -186,12 +182,10 @@ class TestBytesLogger:
         """
         assert repr(BytesLogger()).startswith("<BytesLogger(file=")
 
-    def test_lock(self):
+    def test_lock(self, sio):
         """
         Creating a logger adds a lock to WRITE_LOCKS.
         """
-        sio = StringIO()
-
         assert sio not in WRITE_LOCKS
 
         BytesLogger(sio)

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -2,8 +2,6 @@
 # 2.0, and the MIT License.  See the LICENSE file in the root of this
 # repository for complete details.
 
-
-import collections
 import json
 import logging
 import logging.config
@@ -14,26 +12,18 @@ import pytest
 
 from pretend import call_recorder
 
-from structlog import ReturnLogger, configure, get_context, reset_defaults
-from structlog._log_levels import _NAME_TO_LEVEL, CRITICAL, WARN
-from structlog import ReturnLogger, configure, get_logger, reset_defaults
 from structlog import (
     PrintLogger,
     ReturnLogger,
     configure,
-    get_logger,
+    get_context,
     reset_defaults,
 )
+from structlog._log_levels import _NAME_TO_LEVEL, CRITICAL, WARN
 from structlog.dev import ConsoleRenderer
 from structlog.exceptions import DropEvent
 from structlog.processors import JSONRenderer
 from structlog.stdlib import (
-    _NAME_TO_LEVEL,
-    CRITICAL,
-    WARN,
-    _NAME_TO_LEVEL,
-    CRITICAL,
-    WARN,
     AsyncBoundLogger,
     BoundLogger,
     LoggerFactory,
@@ -47,6 +37,7 @@ from structlog.stdlib import (
     get_logger,
     render_to_log_kwargs,
 )
+from structlog.types import BindableLogger
 
 from .additional_frame import additional_frame
 
@@ -846,67 +837,76 @@ class TestProcessorFormatter:
     reason="AsyncBoundLogger is only for Python 3.7 and later.",
 )
 class TestAsyncBoundLogger:
-    @pytest.mark.parametrize(
-        "level_name",
-        ["debug", "info", "warning", "error", "critical", "exception"],
-    )
     @pytest.mark.asyncio
-    async def test_correct_levels(self, level_name):
+    async def test_protocol(self):
+        """
+        AsyncBoundLogger is a proper BindableLogger.
+        """
+        assert isinstance(AsyncBoundLogger(None, {}, []), BindableLogger)
+
+    @pytest.mark.asyncio
+    async def test_correct_levels(self, cl, stdlib_log_method):
         """
         The proxy methods call the correct upstream methods.
         """
-        _, ed = await getattr(
-            AsyncBoundLogger(
-                ReturnLogger(), context={}, processors=[add_log_level]
-            ).bind(foo="bar"),
-            level_name,
+        await getattr(
+            AsyncBoundLogger(cl, context={}, processors=[]).bind(foo="bar"),
+            stdlib_log_method,
         )("42")
 
-        if level_name == "exception":
-            expect = "error"
-        else:
-            expect = level_name
+        aliases = {"exception": "error", "warn": "warning"}
 
-        assert expect == ed["level"]
+        alias = aliases.get(stdlib_log_method)
+        if alias:
+            expect = alias
+        else:
+            expect = stdlib_log_method
+
+        assert expect == cl.calls[0].method_name
 
     @pytest.mark.asyncio
-    async def test_log_method(self):
+    async def test_log_method(self, cl):
         """
         The `log` method is proxied too.
         """
-        _, ed = (
-            await AsyncBoundLogger(
-                ReturnLogger(), context={}, processors=[add_log_level]
-            )
+        await (
+            AsyncBoundLogger(cl, context={}, processors=[])
             .bind(foo="bar")
             .log(logging.ERROR, "42")
         )
 
-        assert "error" == ed["level"]
+        assert "error" == cl.calls[0].method_name
 
     @pytest.mark.asyncio
-    async def test_bind_unbind(self):
+    async def test_bind_unbind(self, cl):
         """
-        new/bind/unbind are correctly propagated.
-
-        Unbind is actually try_unbind and therefore ignores extra keys.
+        new/bind/unbind/try_unbind are correctly propagated.
         """
-        l1 = AsyncBoundLogger(ReturnLogger(), context={}, processors=[])
+        l1 = AsyncBoundLogger(cl, context={}, processors=[])
 
         l2 = l1.bind(x=42)
 
-        assert {"x": 42} == l1.sync_bl._context
+        assert l1 is not l2
+        assert l1.sync_bl is not l2.sync_bl
+        assert {} == l1._context
+        assert {"x": 42} == l2._context
 
         l3 = l2.new(y=23)
 
-        assert {"y": 23} == l1.sync_bl._context
+        assert l2 is not l3
+        assert l2.sync_bl is not l3.sync_bl
+        assert {"y": 23} == l3._context
+
+        l4 = l3.unbind("y")
+
+        assert {} == l4._context
+        assert l3 is not l4
 
         # N.B. x isn't bound anymore.
-        l4 = l3.unbind("x", "y")
+        l5 = l4.try_unbind("x")
 
-        assert {} == l1.sync_bl._context
-
-        assert l1 is l2 is l3 is l4
+        assert {} == l5._context
+        assert l4 is not l5
 
     @pytest.mark.asyncio
     async def test_integration(self, capsys):

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -5,8 +5,6 @@
 
 import json
 
-from io import StringIO
-
 import pytest
 
 from pretend import call_recorder
@@ -284,11 +282,10 @@ class TestReprWrapper:
 
 
 class TestPlainFileLogObserver:
-    def test_isLogObserver(self):
-        assert ILogObserver.providedBy(PlainFileLogObserver(StringIO()))
+    def test_isLogObserver(self, sio):
+        assert ILogObserver.providedBy(PlainFileLogObserver(sio))
 
-    def test_writesOnlyMessageWithLF(self):
-        sio = StringIO()
+    def test_writesOnlyMessageWithLF(self, sio):
         PlainFileLogObserver(sio)(
             {"system": "some system", "message": ("hello",)}
         )


### PR DESCRIPTION
This is so far only an experimental WiP/PoC. But unless I'm missing anything, adding truly async loggers shouldn't be much of a problem.

---

You can use it like this:

```python
import structlog
import asyncio
import logging
import sys

logging.basicConfig(
    format="%(message)s",
    stream=sys.stdout,
    level=logging.INFO,
)


structlog.configure(
    processors=[
        structlog.stdlib.filter_by_level,
        structlog.stdlib.add_logger_name,
        structlog.stdlib.add_log_level,
        structlog.stdlib.PositionalArgumentsFormatter(),
        structlog.processors.TimeStamper(fmt="iso"),
        structlog.processors.StackInfoRenderer(),
        structlog.processors.format_exc_info,
        structlog.processors.UnicodeDecoder(),
        structlog.processors.JSONRenderer()
    ],
    context_class=dict,
    logger_factory=structlog.stdlib.LoggerFactory(),
    wrapper_class=structlog.stdlib.AsyncBoundLogger,  # <---
    cache_logger_on_first_use=True,
)

logger = structlog.get_logger()

async def main():
    l = logger.bind(foo="bar")

    coro = l.info("qux")
    w = asyncio.sleep(0.5)

    await l.info("baz", x="42")

    await asyncio.gather(coro, w)

asyncio.run(main())
```