### PR TITLE
Implement add_function_name() processor in stdlib module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``structlog.stdlib.add_function_name()`` processor that adds the name of function containing the logging call to the event dictionary.
+  `#246 <https://github.com/hynek/structlog/pull/246>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -222,6 +222,8 @@ API Reference
 
 .. autofunction:: add_logger_name
 
+.. autofunction:: add_function_name
+
 .. autoclass:: PositionalArgumentsFormatter
 
 .. autoclass:: ProcessorFormatter

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -418,6 +418,18 @@ def add_logger_name(logger, method_name, event_dict):
     return event_dict
 
 
+def add_function_name(logger, method_name, event_dict):
+    """
+    Add the name of function containing the logging call to the event dict.
+
+    .. versionadded:: 20.2.0
+    """
+    record = event_dict.get("_record")
+    if record is not None:
+        event_dict["funcName"] = record.funcName
+    return event_dict
+
+
 def render_to_log_kwargs(wrapped_logger, method_name, event_dict):
     """
     Render ``event_dict`` into keyword arguments for `logging.log`.

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -422,6 +422,9 @@ class TestAddFunctionName:
         """
         The calling function name is added to the event dict.
         """
+        event_dict = add_function_name(None, None, {})
+        assert "funcName" not in event_dict
+
         name = "calling_function"
         record = log_record()
         record.funcName = name

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -25,6 +25,7 @@ from structlog.stdlib import (
     PositionalArgumentsFormatter,
     ProcessorFormatter,
     _FixedFindCallerLogger,
+    add_function_name,
     add_log_level,
     add_log_level_number,
     add_logger_name,
@@ -414,6 +415,19 @@ class TestAddLoggerName:
         event_dict = add_logger_name(None, None, {"_record": record})
 
         assert name == event_dict["logger"]
+
+
+class TestAddFunctionName:
+    def test_function_name_added(self, log_record):
+        """
+        The calling function name is added to the event dict.
+        """
+        name = "calling_function"
+        record = log_record()
+        record.funcName = name
+        event_dict = add_function_name(None, None, {"_record": record})
+
+        assert name == event_dict["funcName"]
 
 
 class TestRenderToLogKW:


### PR DESCRIPTION
This PR adds a processor to add the `funcName` field that is automatically added when using standard library logging.

See: https://docs.python.org/3/library/logging.html#logrecord-attributes

# Pull Request Check List
- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).
