### PR TITLE
docs/standard-library.rst: fix typo

### DIFF
--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -146,7 +146,7 @@ Rendering Using ``structlog``-based Formatters Within `logging`
 The `ProcessorFormatter` has two parts to its API:
 
 #. The `structlog.stdlib.ProcessorFormatter.wrap_for_formatter` method must be used as the last processor in `structlog.configure`,
-   it converts the the processed event dict to something that the ``ProcessorFormatter`` understands.
+   it converts the processed event dict to something that the ``ProcessorFormatter`` understands.
 #. The `ProcessorFormatter` itself,
    which can wrap any ``structlog`` renderer to handle the output of both ``structlog`` and standard library events.
 


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
