### PR TITLE
Fix a tiny typo s/threadn-locals/thread-locals

### DIFF
--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -179,7 +179,7 @@ The convenience of having a thread-local context comes at a price though:
 
      See `configuration` for more details.
 
-The general sentiment against threadn-locals is that they're hard to test.
+The general sentiment against thread-locals is that they're hard to test.
 In this case we feel like this is an acceptable trade-off.
 You can easily write deterministic tests using a call-capturing processor if you use the API properly (cf. warning above).
 


### PR DESCRIPTION
On the thread-local docs page

# Pull Request Check List

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).