### PR TITLE
Fix several typos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -211,7 +211,7 @@ Deprecations:
 
 - The meaning of the ``structlog[dev]`` installation target will change from "colorful output" to "dependencies to develop ``structlog``" in 19.1.0.
 
-  The main reason behind this decision is that it's impossible to have a ``structlog`` in your normal dependencies and additionally a ``structlog[dev]`` for developement (``pip`` will report an error).
+  The main reason behind this decision is that it's impossible to have a ``structlog`` in your normal dependencies and additionally a ``structlog[dev]`` for development (``pip`` will report an error).
 
 
 Changes:

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -337,7 +337,7 @@ A basic configuration to output structured logs in JSON format looks like this:
         cache_logger_on_first_use=True,
     )
 
-(If you're still runnning Python 2, replace `UnicodeDecoder` through `UnicodeEncoder`.)
+(If you're still running Python 2, replace `UnicodeDecoder` through `UnicodeEncoder`.)
 
 To make your program behave like a proper `12 factor app`_ that outputs only JSON to ``stdout``, configure the `logging` module like this::
 

--- a/docs/twisted.rst
+++ b/docs/twisted.rst
@@ -36,7 +36,7 @@ Processors
 
       def onError(fail):
          failure = fail.trap(MoonExploded)
-         log.err(failure, _why="event-that-happend")
+         log.err(failure, _why="event-that-happened")
 
    will still work as expected.
 

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -218,9 +218,9 @@ def configure(
 
 def configure_once(*args, **kw):
     """
-    Configures iff structlog isn't configured yet.
+    Configures if structlog isn't configured yet.
 
-    It does *not* matter whether is was configured using `configure` or
+    It does *not* matter whether it was configured using `configure` or
     `configure_once` before.
 
     Raises a `RuntimeWarning` if repeated configuration is attempted.

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -180,7 +180,7 @@ def merge_threadlocal(logger, method_name, event_dict):
 
     .. versionchanged:: 20.1.0
        This function used to be called ``merge_threalocal_context`` and that
-       name is still kept around for backward compatability.
+       name is still kept around for backward compatibility.
     """
     context = _get_context().copy()
     context.update(event_dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,7 @@ from structlog._config import (
 @pytest.fixture
 def proxy():
     """
-    Returns a BoundLoggerLazyProxy constructed w/o paramaters & None as logger.
+    Returns a BoundLoggerLazyProxy constructed w/o parameters & None as logger.
     """
     return BoundLoggerLazyProxy(None)
 

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -87,7 +87,7 @@ class TestPrintLogger:
     @pytest.mark.parametrize("proto", range(pickle.HIGHEST_PROTOCOL))
     def test_pickle_not_stdout_stderr(self, tmpdir, proto):
         """
-        PrintLoggers with differnt files than stdout/stderr raise a
+        PrintLoggers with different files than stdout/stderr raise a
         PickingError.
         """
         f = tmpdir.join("file.log")


### PR DESCRIPTION
Hi!

I was browsing the source code and noticed some typo in "iff" word (macbook keyboard?) 
But then I decided to go further and try out this nice [tool](https://github.com/vlajos/misspell-fixer), so found a bit more 🙂
There's also a [Github Action](https://github.com/sobolevn/misspell-fixer-action) for it if you think it's useful.

Thanks for the awesome library!

_contribution checklist is omitted, cause this is just about typos_