### PR TITLE
Document that capture_logs disables configured processors

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -14,6 +14,8 @@ If you need functionality similar to `unittest.TestCase.assertLogs`, or you want
    >>> cap_logs
    [{'x': 'y', 'event': 'hello', 'log_level': 'info'}]
 
+Note that inside the context manager all configured processors are disabled.
+
 You can build your own helpers using `structlog.testing.LogCapture`.
 For example a `pytest <https://docs.pytest.org/>`_ fixture to capture log output could look like this::
 

--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -41,7 +41,8 @@ class LogCapture:
 def capture_logs():
     """
     Context manager that appends all logging statements to its yielded list
-    while it is active.
+    while it is active. Disables all configured processors for the duration
+    of the context manager.
 
     Attention: this is **not** thread-safe!
 


### PR DESCRIPTION
We got confused at work when `structlog.testing.capture_logs` did not seem to capture `contextvars` bindings. Looking at the implementation made it clear, but it would be nice to document it. Which is what I'm doing here!

Thanks for structlog!

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
