### PR TITLE
Raise useful errors from PrintLogger with bad processor return

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Added better error messages for PrintLogger when the processor chain doesn't return a string.
+  `#263 <https://github.com/hynek/structlog/pull/263>`_
+
 *none*
 
 

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -54,6 +54,7 @@ and call ``log.msg("some_event", y=23)``, it results in the following call chain
    )
 
 In this case, ``f4`` has to make sure it returns something ``wrapped_logger.msg`` can handle (see :ref:`adapting`).
+For the example with ``PrintLogger`` above, this means ``f4`` must return a string.
 
 The simplest modification a processor can make is adding new values to the ``event_dict``.
 Parsing human-readable timestamps is tedious, not so `UNIX timestamps <https://en.wikipedia.org/wiki/UNIX_time>`_ -- let's add one to each log entry!

--- a/src/structlog/_loggers.py
+++ b/src/structlog/_loggers.py
@@ -105,10 +105,13 @@ class PrintLogger:
     def __repr__(self):
         return f"<PrintLogger(file={self._file!r})>"
 
-    def msg(self, message):
+    def msg(self, message, *args, **kwargs):
         """
         Print *message*.
         """
+        if args or kwargs:
+            raise TypeError("PrintLogger can only take a string as argument. "
+                            "Check that the last processor returns a string.")
         with self._lock:
             until_not_interrupted(self._write, message + "\n")
             until_not_interrupted(self._flush)

--- a/src/structlog/_loggers.py
+++ b/src/structlog/_loggers.py
@@ -110,8 +110,10 @@ class PrintLogger:
         Print *message*.
         """
         if args or kwargs:
-            raise TypeError("PrintLogger can only take a string as argument. "
-                            "Check that the last processor returns a string.")
+            raise TypeError(
+                "PrintLogger can only take a string as argument. "
+                "Check that the last processor returns a string."
+            )
         with self._lock:
             until_not_interrupted(self._write, message + "\n")
             until_not_interrupted(self._flush)

--- a/tests/test_loggers.py
+++ b/tests/test_loggers.py
@@ -97,6 +97,16 @@ class TestPrintLogger:
         with pytest.raises(pickle.PicklingError, match="Only PrintLoggers to"):
             pickle.dumps(pl, proto)
 
+    def test_extra_args(self):
+        """
+        PrintLogger only takes a single string arg, no args or kwargs,
+        but supports args/kwargs for better error messages.
+        """
+        with pytest.raises(TypeError):
+            PrintLogger().msg("hello", "foo")
+        with pytest.raises(TypeError):
+            PrintLogger().msg("hello", foo="foo")
+
 
 class TestPrintLoggerFactory:
     def test_does_not_cache(self):


### PR DESCRIPTION
I spent a good chunk of time fighting to get `PrintLogger` working with a simple processor. Turned out that processor was returning a dictionary, not a string. The [documentation](https://www.structlog.org/en/stable/processors.html) does point out that the final processor needs to provide a value that the logger can handle, but I assumed that a `PrintLogger` would just....print the value. (Python does print dicts, after all!)

Anyway, this PR doesn't propose changing that behavior, but rather adds a note to the docs, and also updates `PrintLogger` to take `*args` and `**kwargs`, throwing the `TypeError` itself with a more useful error message. I'm hoping that it will save future users new to structlog some valuable time.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
