### PR TITLE
Add docs clarification for processors example

### DIFF
--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -54,6 +54,7 @@ and call ``log.msg("some_event", y=23)``, it results in the following call chain
    )
 
 In this case, ``f4`` has to make sure it returns something ``wrapped_logger.msg`` can handle (see :ref:`adapting`).
+For the example with ``PrintLogger`` above, this means ``f4`` must return a string.
 
 The simplest modification a processor can make is adding new values to the ``event_dict``.
 Parsing human-readable timestamps is tedious, not so `UNIX timestamps <https://en.wikipedia.org/wiki/UNIX_time>`_ -- let's add one to each log entry!


### PR DESCRIPTION
Added just the doc clarification from #263. I think it's useful even if we don't want to add the clarification at runtime.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
