### PR TITLE
Remove exception control flow from ProcessorFormatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,9 @@ Changes:
 - ``structlog.get_context()`` allows you to retrieve the original context of a bound logger.
   `#266 <https://github.com/hynek/structlog/issues/266>`_,
 
+- ``ProcessorFormatter`` no longer uses exceptions for control flow, allowing
+  ``foreign_pre_chain`` processors to use ``sys.exc_info()`` to access the real
+  exception.
 
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,9 +30,7 @@ Changes:
 - ``structlog.get_context()`` allows you to retrieve the original context of a bound logger.
   `#266 <https://github.com/hynek/structlog/issues/266>`_,
 
-- ``ProcessorFormatter`` no longer uses exceptions for control flow, allowing
-  ``foreign_pre_chain`` processors to use ``sys.exc_info()`` to access the real
-  exception.
+- ``structlog.stdlib.ProcessorFormatter`` no longer uses exceptions for control flow, allowing ``foreign_pre_chain`` processors to use ``sys.exc_info()`` to access the real exception.
 
 ----
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -15,6 +15,7 @@ from structlog._base import BoundLoggerBase
 from structlog._frames import _find_first_app_frame_and_name, _format_stack
 from structlog.exceptions import DropEvent
 
+
 _SENTINEL = object()
 
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -502,8 +502,8 @@ class ProcessorFormatter(logging.Formatter):
         # process the original one
         record = logging.makeLogRecord(record.__dict__)
 
-        logger = getattr(record, '_logger', _SENTINEL)
-        meth_name = getattr(record, '_name', _SENTINEL)
+        logger = getattr(record, "_logger", _SENTINEL)
+        meth_name = getattr(record, "_name", _SENTINEL)
 
         if logger is not _SENTINEL and meth_name is not _SENTINEL:
             # Both attached by wrap_for_formatter

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -499,7 +499,7 @@ class ProcessorFormatter(logging.Formatter):
         # Make a shallow copy of the record to let other handlers/formatters
         # process the original one
         record = logging.makeLogRecord(record.__dict__)
-        try:
+        if hasattr(record, "_logger") and hasattr(record, "_name"):
             # Both attached by wrap_for_formatter
             logger = self.logger if self.logger is not None else record._logger
             meth_name = record._name
@@ -508,7 +508,7 @@ class ProcessorFormatter(logging.Formatter):
             # processed by multiple logging formatters.  LogRecord.getMessage
             # would transform our dict into a str.
             ed = record.msg.copy()
-        except AttributeError:
+        else:
             logger = self.logger
             meth_name = record.levelname.lower()
             ed = {"event": record.getMessage(), "_record": record}

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -15,6 +15,8 @@ from structlog._base import BoundLoggerBase
 from structlog._frames import _find_first_app_frame_and_name, _format_stack
 from structlog.exceptions import DropEvent
 
+_SENTINEL = object()
+
 
 class _FixedFindCallerLogger(logging.Logger):
     """
@@ -499,9 +501,14 @@ class ProcessorFormatter(logging.Formatter):
         # Make a shallow copy of the record to let other handlers/formatters
         # process the original one
         record = logging.makeLogRecord(record.__dict__)
-        if hasattr(record, "_logger") and hasattr(record, "_name"):
+
+        logger = getattr(record, '_logger', _SENTINEL)
+        meth_name = getattr(record, '_name', _SENTINEL)
+
+        if logger is not _SENTINEL and meth_name is not _SENTINEL:
             # Both attached by wrap_for_formatter
-            logger = self.logger if self.logger is not None else record._logger
+            if self.logger is not None:
+                logger = self.logger
             meth_name = record._name
 
             # We need to copy because it's possible that the same record gets

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -503,11 +503,6 @@ class TestProcessorFormatter:
         to logging.
         """
         configure_logging(None)
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         logging.getLogger().warning("foo")
 
@@ -538,11 +533,6 @@ class TestProcessorFormatter:
         """
         test_processor = call_recorder(lambda l, m, event_dict: event_dict)
         configure_logging((test_processor,), pass_foreign_args=True)
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         positional_args = {"foo": "bar"}
         logging.getLogger().info("okay %(foo)s", positional_args)
@@ -571,11 +561,6 @@ class TestProcessorFormatter:
         non-structlog log entries.
         """
         configure_logging((add_log_level,))
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         logging.getLogger().warning("foo")
 
@@ -589,11 +574,6 @@ class TestProcessorFormatter:
         foreign_pre_chain works with add_logger_name processor.
         """
         configure_logging((add_logger_name,))
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         logging.getLogger("sample-name").warning("foo")
 
@@ -632,11 +612,6 @@ class TestProcessorFormatter:
         """
         test_processor = call_recorder(lambda l, m, event_dict: event_dict)
         configure_logging((test_processor,))
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         try:
             raise RuntimeError("oh noo")
@@ -663,11 +638,6 @@ class TestProcessorFormatter:
 
         test_processor = call_recorder(lambda l, m, event_dict: event_dict)
         configure_logging((add_excinfo, test_processor))
-        configure(
-            processors=[ProcessorFormatter.wrap_for_formatter],
-            logger_factory=LoggerFactory(),
-            wrapper_class=BoundLogger,
-        )
 
         try:
             raise MyException("oh noo")

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -784,6 +784,20 @@ class TestProcessorFormatter:
             "[warning  ] foo [in test_native]\n",
         ) == capsys.readouterr()
 
+    def test_native_logger(self, configure_for_pf, capsys):
+        """
+        If the log entry comes from structlog, it's unpackaged and processed.
+        """
+        logger = logging.getLogger()
+        configure_logging(None, logger=logger)
+
+        get_logger().warning("foo")
+
+        assert (
+            "",
+            "[warning  ] foo [in test_native_logger]\n",
+        ) == capsys.readouterr()
+
     def test_foreign_pre_chain_filter_by_level(self, configure_for_pf, capsys):
         """
         foreign_pre_chain works with filter_by_level processor.

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -676,7 +676,7 @@ class TestProcessorFormatter:
 
         event_dict = test_processor.calls[0].args[2]
 
-        assert MyException == event_dict["exc_info"][0]
+        assert MyException is event_dict["exc_info"][0]
 
     def test_other_handlers_get_original_record(
         self, configure_for_pf, capsys


### PR DESCRIPTION
I encountered this issue when combining structlog, stdlib logging, and structlog-sentry. structlog-sentry always attaches the current stack trace to events: https://github.com/kiwicom/structlog-sentry/blob/c15fdb076900e87e577bd0f2d7ef0d847706b366/structlog_sentry/__init__.py#L45 . Unfortunately because `ProcessorFormatter.format` was using an `AttributeError` for control flow, that would mean the current exception fetched by `sys.exc_info()` would always be that `AttributeError`.

This PR adds a test for that case, and changes `ProcessorFormatter.format` to use `hasattr` to check for wrapped event dicts.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
