### PR TITLE
Document that capture_logs() relies on un-cached loggers

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -34,7 +34,7 @@ Here are a few hints how to get most out of ``structlog`` in production:
 
       configure(cache_logger_on_first_use=True)
 
-   This has the only drawback is that later calls on :func:`~structlog.configure` don't have any effect on already cached loggers -- that shouldn't matter outside of testing though.
+   This has the only drawback is that later calls on :func:`~structlog.configure` don't have any effect on already cached loggers -- that shouldn't matter outside of :doc:`testing <testing>` though.
 #. Use a faster JSON serializer than the standard library.
    Possible alternatives are among others simplejson_, orjson_, or RapidJSON_::
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -16,6 +16,11 @@ If you need functionality similar to `unittest.TestCase.assertLogs`, or you want
 
 Note that inside the context manager all configured processors are disabled.
 
+.. note::
+
+  ``capture_logs()`` relies on changing the configuration.
+  If you have *cache_logger_on_first_use* enabled for :doc:`performance <performance>`, any cached loggers will not be affected, so it’s recommended you do not enable it during tests.
+
 You can build your own helpers using `structlog.testing.LogCapture`.
 For example a `pytest <https://docs.pytest.org/>`_ fixture to capture log output could look like this::
 


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
