### PR TITLE
Stop using OrderedDict altogether

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -100,7 +100,7 @@ For ``structlog``, a log entry is just a dictionary called *event dict[ionary]*:
 - As soon as an *event* happens -- which is a dictionary too -- it is merged together with the *context* to an *event dict* and logged out.
 - If you don't like the concept of pre-building a context: just don't!
   Convenient key-value-based logging is great to have on its own.
-- To keep as much order of the keys as possible, an `collections.OrderedDict` is used for the context by default for Pythons that do not have ordered dictionaries by default (notably all versions of CPython before 3.6).
+- Python keeps dictionaries ordered by keys by default.
 - The recommended way of binding values is the one in these examples: creating new loggers with a new context.
   If you're okay with giving up immutable local state for convenience, you can also use `thread/greenlet local storage <thread-local>` or :doc:`context variables <contextvars>` for the context.
 

--- a/docs/loggers.rst
+++ b/docs/loggers.rst
@@ -91,8 +91,7 @@ As you can see, it accepts one mandatory and a few optional arguments:
    The class to save your context in.
    Particularly useful for `thread local context storage <thread-local>`.
 
-   On Python versions that have ordered dictionaries (Python 3.6+, PyPy) the default is a plain `dict`.
-   For everything else it's `collections.OrderedDict`.
+   Since Python 3.6+ and PyPy have ordered dictionaries, the default is a plain `dict`.
 
 Additionally, the following arguments are allowed too:
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,11 +5,7 @@
 
 import abc
 import pickle
-import platform
-import sys
 import warnings
-
-from collections import OrderedDict
 
 import pytest
 
@@ -62,18 +58,9 @@ def test_lazy_logger_is_not_detected_as_abstract_method():
 
 def test_default_context_class():
     """
-    Default context class is dict on Python 3.6+ and PyPy, OrderedDict
-    otherwise.
+    Default context class is dict on Python 3.6+ and PyPy
     """
-    if platform.python_implementation() == "PyPy" or sys.version_info[:2] >= (
-        3,
-        6,
-    ):
-        cls = dict
-    else:
-        cls = OrderedDict
-
-    assert cls is _BUILTIN_DEFAULT_CONTEXT_CLASS
+    assert dict is _BUILTIN_DEFAULT_CONTEXT_CLASS
 
 
 class TestConfigure:

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -3,7 +3,6 @@
 # repository for complete details.
 
 
-import collections
 import logging
 import logging.config
 import os
@@ -684,7 +683,6 @@ class TestProcessorFormatter:
         logger = logging.getLogger()
 
         def format_exc_info_fake(logger, name, event_dict):
-            event_dict = collections.OrderedDict(event_dict)
             del event_dict["exc_info"]
             event_dict["exception"] = "Exception!"
             return event_dict

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -5,8 +5,6 @@
 
 import threading
 
-from collections import OrderedDict
-
 import pytest
 
 from structlog._base import BoundLoggerBase
@@ -43,9 +41,9 @@ def D():
 @pytest.fixture
 def log(logger):
     """
-    Returns a ReturnLogger with a freshly wrapped OrderedDict.
+    Returns a ReturnLogger with a freshly wrapped dict.
     """
-    return wrap_logger(logger, context_class=wrap_dict(OrderedDict))
+    return wrap_logger(logger, context_class=wrap_dict(dict))
 
 
 @pytest.fixture

--- a/tests/test_twisted.py
+++ b/tests/test_twisted.py
@@ -5,7 +5,6 @@
 
 import json
 
-from collections import OrderedDict
 from io import StringIO
 
 import pytest
@@ -230,7 +229,7 @@ class TestJSONRenderer:
         JSONRenderer allows for setting arguments that are passed to
         json.dumps().  Make sure they are passed.
         """
-        d = OrderedDict(x="foo")
+        d = {"x": "foo"}
         d.update(a="bar")
         jr_sorted = JSONRenderer(sort_keys=True)
 


### PR DESCRIPTION
When removing support for 2.7/3.5, most instances of OrderedDict were removed: this finishes the work. As a user, I was particularly confused by the mentions of OrderedDict in the docs for Python <3.6.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).
