### PR TITLE
Implement native log levels though an optimized bound logger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,9 +39,10 @@ Changes:
   Please feel free to provide feedback!
   `#223 <https://github.com/hynek/structlog/issues/223>`_,
   `#282 <https://github.com/hynek/structlog/issues/282>`_
-- Added ``structlog.processors.LevelFilter`` that can filter log entries based on the names of the log methods (and uses the same order as standard library's logging).
-  `#283 <https://github.com/hynek/structlog/issues/283>`_
-- As a complement, ``structlog.stdlib.add_log_level()`` can now also be imported as ``structlog.processors.add_log_level`` since it just adds the method name to the event dict.
+- Added ``structlog.make_filtering_logger`` that can be used like ``configure(wrapper_class=make_filtering_bound_logger(logging.INFO))``.
+  It creates a highly optimized bound logger whose inactive methods only consist of a ``return None``.
+  This is now also the default logger.
+- As a complement, ``structlog.stdlib.add_log_level()`` can now additionally be imported as ``structlog.processors.add_log_level`` since it just adds the method name to the event dict.
 - ``structlog.processors.add_log_level()`` is now part of the default configuration.
 - ``structlog.stdlib.ProcessorFormatter`` no longer uses exceptions for control flow, allowing ``foreign_pre_chain`` processors to use ``sys.exc_info()`` to access the real exception.
 - Added ``structlog.BytesLogger`` to avoid unnecessary encoding round trips.
@@ -52,6 +53,7 @@ Changes:
   `#266 <https://github.com/hynek/structlog/issues/266>`_,
 - ``structlog.PrintLogger`` now supports ``copy.deepcopy()``.
   `#268 <https://github.com/hynek/structlog/issues/268>`_
+- Added ``structlog.testing.CapturingLogger`` for more unittesting goodness.
 
 
 ----
@@ -129,7 +131,7 @@ Changes:
   `#215 <https://github.com/hynek/structlog/issues/215>`_
 - ``structlog.dev.ConsoleRenderer`` now initializes ``colorama`` lazily, to prevent accidental side-effects just by importing ``structlog``.
   `#210 <https://github.com/hynek/structlog/issues/210>`_
-- Added new processor ``structlog.dev.set_exc_info()`` that will set ``exc_info=True`` if the method's name is `exception` and ``exc_info`` isn't set at all.
+- Added new processor ``structlog.dev.set_exc_info()`` that will set ``exc_info=True`` if the method's name is ``exception`` and ``exc_info`` isn't set at all.
   *This is only necessary when the standard library integration is not used*.
   It fixes the problem that in the default configuration, ``structlog.get_logger().exception("hi")`` in an ``except`` block would not print the exception without passing ``exc_info=True`` to it explicitly.
   `#130 <https://github.com/hynek/structlog/issues/130>`_,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,8 @@ API Reference
 .. autoclass:: BoundLogger
    :members: new, bind, unbind
 
+.. autofunction:: make_filtering_bound_logger
+
 .. autofunction:: get_context
 
 .. autoclass:: PrintLogger
@@ -81,10 +83,25 @@ API Reference
 
 .. autofunction:: capture_logs
 .. autoclass:: LogCapture
+
+.. autoclass:: CapturingLogger
+
+   >>> from pprint import pprint
+   >>> cl = structlog.testing.CapturingLogger()
+   >>> cl.msg("hello")
+   >>> cl.msg("hello", when="again")
+   >>> pprint(cl.calls)
+   [CapturedCall(method_name='msg', args=('hello',), kwargs={}),
+    CapturedCall(method_name='msg', args=('hello',), kwargs={'when': 'again'})]
+
+.. autoclass:: CapturingLoggerFactory
+.. autoclass:: CapturedCall
+
 .. autoclass:: ReturnLogger
    :members: msg, err, debug, info, warning, error, critical, log, failure, fatal
 
 .. autoclass:: ReturnLoggerFactory
+
 
 
 `structlog.threadlocal` Module
@@ -176,8 +193,6 @@ API Reference
       'b=[1, 2, 3] a=42'
 
 
-.. autoclass:: LevelFilter
-
 .. autofunction:: add_log_level
 
 .. autoclass:: UnicodeDecoder
@@ -256,6 +271,8 @@ API Reference
    Unfortunately it's impossible to define initializers using `PEP 544 <https://www.python.org/dev/peps/pep-0544/>`_ Protocols.
 
    They currently also have to carry a `Context` as a ``_context`` attribute.
+
+.. autoprotocol:: FilteringBoundLogger
 
 .. autodata:: EventDict
 .. autodata:: WrappedLogger

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -39,7 +39,9 @@ Here, ``structlog`` takes full advantage of its hopefully useful default setting
 It should be noted that even in most complex logging setups the example would still look just like that thanks to `configuration`.
 Using the defaults, as above, is equivalent to::
 
+   import loggging
    import structlog
+
    structlog.configure(
        processors=[
            structlog.processors.add_log_level,
@@ -49,7 +51,7 @@ Using the defaults, as above, is equivalent to::
            structlog.processors.TimeStamper(),
            structlog.dev.ConsoleRenderer()
        ],
-       wrapper_class=structlog.BoundLogger,
+       wrapper_class=structlog.make_filtering_bound_logger(logging.NOTSET),
        context_class=dict,
        logger_factory=structlog.PrintLoggerFactory(),
        cache_logger_on_first_use=False
@@ -58,6 +60,9 @@ Using the defaults, as above, is equivalent to::
 
 .. note::
    For brevity and to enable doctests, all further examples in ``structlog``'s documentation use the more simplistic `structlog.processors.KeyValueRenderer()` without timestamps.
+
+   `structlog.make_filtering_bound_logger()` (re-)uses `logging`'s log levels, but doesn't use it at all.
+   The exposed API is `FilteringBoundLogger`.
 
 There you go, structured logging!
 However, this alone wouldn't warrant its own package.

--- a/docs/loggers.rst
+++ b/docs/loggers.rst
@@ -52,14 +52,18 @@ For that times there is the `structlog.wrap_logger` function that can be used to
 
 .. doctest::
 
-   >>> from structlog import wrap_logger
-   >>> class PrintLogger:
+   >>> import structlog
+   >>> class CustomPrintLogger:
    ...     def msg(self, message):
    ...         print(message)
    >>> def proc(logger, method_name, event_dict):
    ...     print("I got called with", event_dict)
    ...     return repr(event_dict)
-   >>> log = wrap_logger(PrintLogger(), processors=[proc], context_class=dict)
+   >>> log = structlog.wrap_logger(
+   ...     CustomPrintLogger(),
+   ...     wrapper_class=structlog.BoundLogger,
+   ...     processors=[proc],
+   ... )
    >>> log2 = log.bind(x=42)
    >>> log == log2
    False

--- a/docs/logging-best-practices.rst
+++ b/docs/logging-best-practices.rst
@@ -24,7 +24,8 @@ Centralized Logging
 -------------------
 
 Nowadays you usually don't want your logfiles in compressed archives distributed over dozens -- if not thousands -- of servers or cluster nodes.
-You want them in a single location; parsed, indexed, and easy to search.
+You want them in a single location.
+Parsed, indexed, and easy to search.
 
 
 ELK
@@ -33,11 +34,11 @@ ELK
 The ELK stack (Elasticsearch_, Logstash_, Kibana_) from Elastic is a great way to store, parse, and search your logs.
 
 The way it works is that you have local log shippers like Filebeat_ that parse your log files and forward the log entries to your Logstash_ server.
-Logstash parses the log entries and stores them in in Elasticsearch_.
+Logstash parses the log entries and stores them in Elasticsearch_.
 Finally, you can view and search them in Kibana_.
 
 If your log entries consist of a JSON dictionary, this is fairly easy and efficient.
-All you have to do is to tell Logstash_ the name of your timestamp field.
+All you have to do is to tell Logstash_ either that your log entries are prepended with a timestamp from `TimeStamper` or the name of your timestamp field.
 
 
 Graylog

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,23 +1,22 @@
 Performance
 ===========
 
-``structlog``'s default configuration tries to be as unsurprising and not confusing to new developers as possible.
+``structlog``'s default configuration tries to be as unsurprising to new developers as possible.
 Some of the choices made come with an avoidable performance price tag -- although its impact is debatable.
 
 Here are a few hints how to get most out of ``structlog`` in production:
 
-#. Use plain `dict`\ s as context classes.
-   Python is full of them and they are highly optimized::
-
-      configure(context_class=dict)
-
-   If you don't use automated parsing (you should!) and need predictable order of your keys for some reason, use the *key_order* argument of :class:`~structlog.processors.KeyValueRenderer`.
 #. Use a specific wrapper class instead of the generic one.
    ``structlog`` comes with ones for the :doc:`standard-library` and for :doc:`twisted`::
 
       configure(wrapper_class=structlog.stdlib.BoundLogger)
 
+   ``structlog`` also comes with native log levels that are based on the ones from the standard library (read: we've copy and pasted them), but don't involve `logging`'s dynamic machinery.
+   That makes them *much* faster.
+   You can use `structlog.make_filtering_bound_logger()` to create one.
+
    :doc:`Writing own wrapper classes <custom-wrappers>` is straightforward too.
+
 #. Avoid (frequently) calling log methods on loggers you get back from :func:`structlog.wrap_logger` and :func:`structlog.get_logger`.
    Since those functions are usually called in module scope and thus before you are able to configure them, they return a proxy that assembles the correct logger on demand.
 
@@ -35,15 +34,60 @@ Here are a few hints how to get most out of ``structlog`` in production:
       configure(cache_logger_on_first_use=True)
 
    This has the only drawback is that later calls on :func:`~structlog.configure` don't have any effect on already cached loggers -- that shouldn't matter outside of :doc:`testing <testing>` though.
-#. Use a faster JSON serializer than the standard library.
-   Possible alternatives are among others simplejson_, orjson_, or RapidJSON_::
 
-      structlog.processors.JSONRenderer(serializer=rapidjson.dumps)
-
-#. Avoid sending your log entries through the standard library if you can: it's a major bottleneck.
+#. Avoid sending your log entries through the standard library if you can: its dynamic nature and flexibiliy make it a major bottleneck.
    Instead use `structlog.PrintLoggerFactory` or -- if your serializer returns bytes (e.g. orjson_) -- `structlog.BytesLoggerFactory`.
 
    You can still configure `logging` for packages that you don't control, but avoid it for your *own* log entries.
+
+#. Use a faster JSON serializer than the standard library.
+   Possible alternatives are among others are orjson_ or RapidJSON_.
+
+
+Example
+-------
+
+
+Here's an example for a production-ready non-asyncio ``structlog`` configuration that's as fast as it gets::
+
+  import logging
+  import structlog
+
+  structlog.configure(
+      cache_logger_on_first_use=True,
+      wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+      processors=[
+          structlog.threadlocal.merge_threadlocal_context,
+          structlog.processors.add_log_level,
+          structlog.processors.format_exc_info,
+          structlog.processors.TimeStamper(fmt="iso", utc=False),
+          structlog.processors.JSONRenderer(serializer=orjson.dumps),
+      ],
+      logger_factory=structlog.BytesLoggerFactory(),
+  )
+
+It has the following properties:
+
+- Caches all loggers on first use.
+- Filters all log entries below the ``info`` log level **very** efficiently.
+  The ``debug`` method literally consists of ``return None``.
+- Supports `thread-local`.
+- Adds the log level name.
+- Renders exceptions.
+- Adds an `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ timestamp under the ``timestamp`` key in the UTC timezone.
+- Renders the log entries as JSON using orjson_ which is faster than plain logging in `logging`.
+- Uses `BytesLoggerFactory` because orjson returns bytes.
+  That saves encoding ping-pong.
+
+Therefore a log entry might look like this:
+
+.. code:: json
+
+   {"event":"hello","timestamp":"2020-11-17T09:54:11.900066Z"}
+
+----
+
+If you need standard library support for external projects, you can either just use a JSON formatter like `python-json-logger <https://pypi.org/project/python-json-logger/>`_, or pipe them through ``structlog`` as documented in `standard-library`.
 
 
 .. _simplejson: https://simplejson.readthedocs.io/

--- a/docs/processors.rst
+++ b/docs/processors.rst
@@ -85,7 +85,7 @@ How about dropping only log entries that are marked as coming from a certain pee
    :language: python
 
 
-Since it's so common to filter by the log level, ``structlog`` comes with `structlog.processors.LevelFilter`.
+Since it's so common to filter by the log level, ``structlog`` comes with `structlog.make_filtering_bound_logger` that filters log entries before they even enter the processor chain..
 It does **not** use the standard library, but it does use its names and order of log levels.
 In practice, it only looks up the numeric value of the method name and compares it to the configured minimal level.
 That's fast and usually good enough for applications.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -40,6 +40,25 @@ For example a `pytest <https://docs.pytest.org/>`_ fixture to capture log output
 
 ----
 
+You can also use `structlog.testing.CapturingLogger` (directly, or via `CapturingLoggerFactory` that always returns the same logger) that is more low-level and great for unit tests:
+
+.. doctest::
+
+   >>> import structlog
+   >>> cf = structlog.testing.CapturingLoggerFactory()
+   >>> structlog.configure(logger_factory=cf, processors=[structlog.processors.JSONRenderer()])
+   >>> log = get_logger()
+   >>> log.info("test!")
+   >>> cf.logger.calls
+   [CapturedCall(method_name='info', args=('{"event": "test!"}',), kwargs={})]
+
+.. testcleanup:: *
+
+   import structlog
+   structlog.reset_defaults()
+
+----
+
 Additionally ``structlog`` also ships with a logger that just returns whatever it gets passed into it: `structlog.testing.ReturnLogger`.
 
 .. doctest::

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -140,7 +140,7 @@ In order to be able to bind values temporarily to a logger, `structlog.threadloc
 .. doctest:: ctx
 
    >>> log.bind(x=42)  # doctest: +ELLIPSIS
-   <BoundLogger(context=<WrappedDict-...({'x': 42})>, ...)>
+   <BoundLoggerFilteringAtNotset(context=<WrappedDict-...({'x': 42})>, ...)>
    >>> log.msg("event!")
    x=42 event='event!'
    >>> with tmp_bind(log, x=23, y="foo") as tmp_log:

--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -20,6 +20,7 @@ from structlog._config import (
     wrap_logger,
 )
 from structlog._generic import BoundLogger
+from structlog._log_levels import make_filtering_bound_logger
 from structlog._loggers import (
     BytesLogger,
     BytesLoggerFactory,
@@ -73,6 +74,7 @@ __all__ = [
     "get_context",
     "get_logger",
     "is_configured",
+    "make_filtering_bound_logger",
     "processors",
     "reset_defaults",
     "stdlib",

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -21,7 +21,7 @@ from typing import (
     cast,
 )
 
-from ._generic import BoundLogger
+from ._log_levels import make_filtering_bound_logger
 from ._loggers import PrintLoggerFactory
 from .dev import ConsoleRenderer, _has_colorama, set_exc_info
 from .processors import (
@@ -47,7 +47,7 @@ _BUILTIN_DEFAULT_PROCESSORS: Sequence[Processor] = [
     ConsoleRenderer(colors=_has_colorama and sys.stdout.isatty()),
 ]
 _BUILTIN_DEFAULT_CONTEXT_CLASS = cast(Type[Context], dict)
-_BUILTIN_DEFAULT_WRAPPER_CLASS = BoundLogger
+_BUILTIN_DEFAULT_WRAPPER_CLASS = make_filtering_bound_logger(0)
 _BUILTIN_DEFAULT_LOGGER_FACTORY = PrintLoggerFactory()
 _BUILTIN_CACHE_LOGGER_ON_FIRST_USE = False
 

--- a/src/structlog/types.py
+++ b/src/structlog/types.py
@@ -104,3 +104,65 @@ class BindableLogger(Protocol):
 
     def new(self, **new_values: Any) -> "BindableLogger":
         ...
+
+
+class FilteringBoundLogger(BindableLogger, Protocol):
+    """
+    A `BindableLogger` that filters by a level.
+
+    Currently, the only way to instantiate one is using
+    `make_filtering_bound_logger`.
+
+    .. versionadded:: 20.2.0
+    """
+
+    def debug(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **debug** level.
+        """
+
+    def info(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **info** level.
+        """
+
+    def warning(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **warn** level.
+        """
+
+    def warn(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **warn** level.
+        """
+
+    def error(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **error** level.
+        """
+
+    def err(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **error** level.
+        """
+
+    def fatal(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **critical** level.
+        """
+
+    def exception(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **error** level and ensure that ``exc_info``
+        is set in the event dictionary.
+        """
+
+    def critical(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **critical** level.
+        """
+
+    def msg(self, event: str, **kw: Any) -> Any:
+        """
+        Log *event* with **kw** at **info** level.
+        """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -326,7 +326,7 @@ class TestBoundLoggerLazyProxy:
         class F:
             "New logger factory with a new attribute"
 
-            def a(self, *args):
+            def info(self, *args):
                 return 5
 
         proxy = BoundLoggerLazyProxy(None)
@@ -334,7 +334,7 @@ class TestBoundLoggerLazyProxy:
         configure(logger_factory=F)
         new_b = proxy.bind()
 
-        assert new_b.a("test") == 5
+        assert new_b.info("test") == 5
 
     def test_emphemeral(self):
         """

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -1,0 +1,55 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the MIT License.  See the LICENSE file in the root of this
+# repository for complete details.
+
+import logging
+
+import pytest
+
+from structlog import make_filtering_bound_logger
+from structlog.testing import CapturingLogger
+
+
+@pytest.fixture(name="cl")
+def fixture_cl():
+    return CapturingLogger()
+
+
+@pytest.fixture(name="bl")
+def fixture_bl(cl):
+    return make_filtering_bound_logger(logging.INFO)(cl, [], {})
+
+
+class TestFilteringLogger:
+    def test_exact_level(self, bl, cl):
+        """
+        if log level is exactly the min_level, log.
+        """
+        bl.info("yep")
+
+        assert [("info", (), {"event": "yep"})] == cl.calls
+
+    def test_one_below(self, bl, cl):
+        """
+        if log level is exactly the min_level, log.
+        """
+        bl.debug("nope")
+
+        assert [] == cl.calls
+
+    def test_exception(self, bl, cl):
+        """
+        exception ensures that exc_info is set to True, unless it's already
+        set.
+        """
+        bl.exception("boom")
+
+        assert [("error", (), {"event": "boom", "exc_info": True})]
+
+    def test_exception_passed(self, bl, cl):
+        """
+        exception if exc_info has a value, exception doesn't tamper with it.
+        """
+        bl.exception("boom", exc_info=42)
+
+        assert [("error", (), {"event": "boom", "exc_info": 42})]

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -18,7 +18,6 @@ from structlog.processors import (
     ExceptionPrettyPrinter,
     JSONRenderer,
     KeyValueRenderer,
-    LevelFilter,
     StackInfoRenderer,
     TimeStamper,
     UnicodeDecoder,
@@ -539,41 +538,3 @@ class TestFigureOutExcInfo:
         e = ValueError()
 
         assert (e.__class__, e, None) == _figure_out_exc_info(e)
-
-
-class TestLevelFilter:
-    @pytest.mark.parametrize("min_level", ["notset", 0, "nOtSeT"])
-    def test_passes(self, min_level):
-        """
-        If the log level is higher than the configured one, pass it through.
-        """
-        lf = LevelFilter(min_level, pass_unknown=False)
-
-        assert {"foo": 42} == lf(None, "debug", {"foo": 42})
-
-    @pytest.mark.parametrize("min_level", ["info", 20, "iNfO"])
-    def test_drop(self, min_level):
-        """
-        If the log level is less than the configured one, raise DropEvent.
-        """
-        lf = LevelFilter(min_level, pass_unknown=False)
-
-        with pytest.raises(structlog.DropEvent):
-            lf(None, "debug", {"foo": 42})
-
-    def test_pass_unknown(self):
-        """
-        If pass_unknown is True, unknown log levels always pass.
-        """
-        lf = LevelFilter(0, pass_unknown=True)
-
-        assert {"foo": 42} == lf(None, "unknown", {"foo": 42})
-
-    def test_drop_unknown(self):
-        """
-        If pass_unknown is False, unknown log levels always raise DropEvent.
-        """
-        lf = LevelFilter(0, pass_unknown=False)
-
-        with pytest.raises(structlog.DropEvent):
-            lf(None, "unknown", {"foo": 42})


### PR DESCRIPTION
Remove LevelFilter, this is much faster.

Since we needed a better way for testing, I've also added CapturingLogger.