### PR TITLE
Fix type of contextvars.merge_contextvars

### DIFF
--- a/src/structlog/contextvars.py
+++ b/src/structlog/contextvars.py
@@ -15,7 +15,7 @@ import contextvars
 
 from typing import Any, Dict
 
-from .types import Context, WrappedLogger
+from .types import Context, EventDict, WrappedLogger
 
 
 _CONTEXT: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
@@ -24,8 +24,8 @@ _CONTEXT: contextvars.ContextVar[Dict[str, Any]] = contextvars.ContextVar(
 
 
 def merge_contextvars(
-    logger: WrappedLogger, method_name: str, event_dict: Dict[str, Any]
-) -> Context:
+    logger: WrappedLogger, method_name: str, event_dict: EventDict
+) -> EventDict:
     """
     A processor that merges in a global (context-local) context.
 


### PR DESCRIPTION
With the current type, using it in a processor chain requires a
cast to `types.Processor`; replace use of `types.Context` with
`types.EventDict` to fix that.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/master/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!