### PR TITLE
Add missing backtick to ExceptionPrettyPrinter docstring

### DIFF
--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -391,7 +391,7 @@ class ExceptionPrettyPrinter:
     This processor is mostly for development and testing so you can read
     exceptions properly formatted.
 
-    It behaves like format_exc_info` except it removes the exception
+    It behaves like `format_exc_info` except it removes the exception
     data from the event dictionary after printing it.
 
     It's tolerant to having `format_exc_info` in front of itself in the


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
