### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -39,7 +39,7 @@ Here are a few hints how to get most out of ``structlog`` in production:
    2. The resulting bound logger is not pickleable.
       Therefore, you can't set this option if you e.g. plan on passing loggers around using `multiprocessing`.
 
-#. Avoid sending your log entries through the standard library if you can: its dynamic nature and flexibiliy make it a major bottleneck.
+#. Avoid sending your log entries through the standard library if you can: its dynamic nature and flexibility make it a major bottleneck.
    Instead use `structlog.PrintLoggerFactory` or -- if your serializer returns bytes (e.g. orjson_) -- `structlog.BytesLoggerFactory`.
 
    You can still configure `logging` for packages that you don't control, but avoid it for your *own* log entries.

--- a/docs/thread-local.rst
+++ b/docs/thread-local.rst
@@ -79,7 +79,7 @@ Thread-local Contexts
 
 ``structlog`` also provides thread-local context storage in a form that you may already know from `Flask <https://flask.palletsprojects.com/en/master/design/#thread-locals>`_ and that makes the *entire context* global to your thread or greenlet.
 
-This makes its behavior more difficult to reason about which is why we generally recomment to use the `merge_threadlocal` route.
+This makes its behavior more difficult to reason about which is why we generally recommend to use the `merge_threadlocal` route.
 
 
 Wrapped Dicts

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,15 @@ EXTRAS_REQUIRE = {
         "pytest>=6.0",
         "simplejson",
     ],
-    "docs": ["furo", "sphinx", "sphinx-toolbox", "twisted"],
+    "docs": [
+        "furo",
+        "sphinx",
+        "twisted",
+        # explicitly list sphinx-toolbox dependencies
+        "sphinx-toolbox",
+        "cachecontrol",
+        "lockfile",
+    ],
 }
 EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["docs"] + ["pre-commit"]

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -30,7 +30,7 @@ _EVENT_WIDTH = 30  # pad the event name to so many characters
 
 def _pad(s: str, length: int) -> str:
     """
-    Pads *s* to length *lenght*.
+    Pads *s* to length *length*.
     """
     missing = length - len(s)
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -426,7 +426,7 @@ class AsyncBoundLogger:
     def bind(self, **new_values: Any) -> "AsyncBoundLogger":
         return AsyncBoundLogger(
             # logger, processors and context are within sync_bl. These
-            # arguments are ignored if _sync_bl is passsed. *vroom vroom* over
+            # arguments are ignored if _sync_bl is passed. *vroom vroom* over
             # purity.
             logger=None,  # type: ignore
             processors=(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,7 +211,7 @@ class TestBoundLoggerLazyProxy:
 
     def test_bind_honors_initial_values(self):
         """
-        Passed initia_values are merged on binds.
+        Passed initial_values are merged on binds.
         """
         p = BoundLoggerLazyProxy(None, initial_values={"a": 1, "b": 2})
         b = p.bind()

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -188,7 +188,7 @@ class TestBoundLogger:
 
     def test_proxies_log(self):
         """
-        BoundLogger.exception.log() is proxied to the apropriate method.
+        BoundLogger.exception.log() is proxied to the appropriate method.
         """
         bl = BoundLogger(ReturnLogger(), [return_method_name], {})
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -42,7 +42,7 @@ class TestCaptureLogs:
 
     def test_restores_processors_on_success(self):
         """
-        Processors are patched within the contextmanger and restored on
+        Processors are patched within the contextmanager and restored on
         exit.
         """
         orig_procs = self.get_active_procs()


### PR DESCRIPTION
There are small typos in:
- docs/performance.rst
- docs/thread-local.rst
- src/structlog/dev.py
- src/structlog/stdlib.py
- tests/test_config.py
- tests/test_stdlib.py
- tests/test_testing.py

Fixes:
- Should read `passed` rather than `passsed`.
- Should read `length` rather than `lenght`.
- Should read `initial` rather than `initia`.
- Should read `flexibility` rather than `flexibiliy`.
- Should read `contextmanager` rather than `contextmanger`.
- Should read `appropriate` rather than `apropriate`.
- Should read `recommend` rather than `recomment`.

Closes #319

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
