### PR TITLE
Fix typo in performance.rst

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -64,7 +64,7 @@ Here's an example for a production-ready non-asyncio ``structlog`` configuration
           structlog.threadlocal.merge_threadlocal_context,
           structlog.processors.add_log_level,
           structlog.processors.format_exc_info,
-          structlog.processors.TimeStamper(fmt="iso", utc=False),
+          structlog.processors.TimeStamper(fmt="iso", utc=True),
           structlog.processors.JSONRenderer(serializer=orjson.dumps),
       ],
       logger_factory=structlog.BytesLoggerFactory(),


### PR DESCRIPTION
Updated the sample code to include `TimeStamper(utc=True)` instead of `False`.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.rst` by hand.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [X] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
