### PR TITLE
add processor_chain arg to stdlib.ProcessorFormatter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changes:
 - If the `better-exceptions <https://github.com/qix-/better-exceptions>`_ package is present, ``structlog.dev.ConsoleRenderer`` will now pretty-print exceptions using it.
   Pass ``pretty_exceptions=False`` to disable.
   This only works if ``format_exc_info`` is **absent** in the processor chain.
+- Added ``processor_chain`` argument to ``structlog.stdlib.ProcessorFormatter``.
 
 
 ----
@@ -44,7 +45,8 @@ Changes:
 Backward-incompatible changes:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*none*
+- ``structlog.stdlib.ProcessorFormatter`` no longer has a ``processor`` attribute.
+  Use ``processor_chain`` instead.
 
 
 Deprecations:

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -733,8 +733,7 @@ class ProcessorFormatter(logging.Formatter):
     def __init__(
         self,
         processor: Optional[Processor] = None,
-        processor_chain: Optional[Sequence[Processor]
-        ] = None,
+        processor_chain: Optional[Sequence[Processor]] = None,
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,
         keep_stack_info: bool = False,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -737,8 +737,7 @@ class ProcessorFormatter(logging.Formatter):
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,
         keep_stack_info: bool = False,
-        logger: Optional[logging.Logger
-        ] = None,
+        logger: Optional[logging.Logger] = None,
         pass_foreign_args: bool = False,
         *args: Any,
         **kwargs: Any,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -750,7 +750,9 @@ class ProcessorFormatter(logging.Formatter):
         elif processor is not None and processor_chain is None:
             self.processor_chain = [processor]
         else:
-            raise TypeError("you must specify processor or processor_chain, but not both")
+            raise TypeError(
+                "you must specify processor or processor_chain, but not both"
+            )
 
         self.foreign_pre_chain = foreign_pre_chain
         self.keep_exc_info = keep_exc_info

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -706,7 +706,7 @@ class ProcessorFormatter(logging.Formatter):
         A ``structlog`` processor, or `None` to use *processor_chain* instead.
     :param processor_chain:
         If not `None`, each processor in the chain will be applied to all log
-        entries. If `None` (the default), `processor` will be used instead.
+        entries. If `None` (the default), *processor* will be used instead.
     :param foreign_pre_chain:
         Similar to *processor_chain*, but applied only to non-``structlog`` log
         entries, and before *processor_chain*.  If `None` or empty, formatting
@@ -733,7 +733,8 @@ class ProcessorFormatter(logging.Formatter):
     def __init__(
         self,
         processor: Optional[Processor] = None,
-        processor_chain: Optional[Sequence[Processor]] = None,
+        processor_chain: Optional[Sequence[Processor]
+        ] = None,
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,
         keep_stack_info: bool = False,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -732,8 +732,7 @@ class ProcessorFormatter(logging.Formatter):
 
     def __init__(
         self,
-        processor: Optional[
-            Processor] = None,
+        processor: Optional[Processor] = None,
         processor_chain: Optional[Sequence[Processor]] = None,
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -703,7 +703,7 @@ class ProcessorFormatter(logging.Formatter):
     Please refer to :doc:`standard-library` for examples.
 
     :param processor:
-        A ``structlog`` processor, or `None` to use `processor_chain` instead.
+        A ``structlog`` processor, or `None` to use *processor_chain* instead.
     :param processor_chain:
         If not `None`, each processor in the chain will be applied to all log
         entries. If `None` (the default), `processor` will be used instead.
@@ -732,7 +732,8 @@ class ProcessorFormatter(logging.Formatter):
 
     def __init__(
         self,
-        processor: Optional[Processor],
+        processor: Optional[
+            Processor] = None,
         processor_chain: Optional[Sequence[Processor]] = None,
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -737,7 +737,8 @@ class ProcessorFormatter(logging.Formatter):
         foreign_pre_chain: Optional[Sequence[Processor]] = None,
         keep_exc_info: bool = False,
         keep_stack_info: bool = False,
-        logger: Optional[logging.Logger] = None,
+        logger: Optional[logging.Logger
+        ] = None,
         pass_foreign_args: bool = False,
         *args: Any,
         **kwargs: Any,
@@ -817,7 +818,7 @@ class ProcessorFormatter(logging.Formatter):
 
         for proc in self.processor_chain:
             ed = proc(logger, meth_name, ed)
-        record.msg = ed  # type: ignore
+        record.msg = ed
 
         return super().format(record)
 


### PR DESCRIPTION
Fixes #334 

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

I'll add tests if any of this is actually a good idea. I'm new to structlog and there might already be a way to do what I wanted to do in #334 .