### PR TITLE
Add reset_contextvars and update bind_contextvars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Changes:
   You can keep using ``colorama`` to customize colors, of course.
 - The final processor can now return a ``bytearray`` (additionally to ``str`` and ``bytes``).
   `#344 <https://github.com/hynek/structlog/issues/344>`_
+- ``structlog.contextvars.bind_contextvars()`` now returns a mapping of keys to ``contextvars.Token``\s, allowing you to reset values using the new ``structlog.contextvars.reset_contextvars()``.
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -176,6 +176,7 @@ Please see :doc:`thread-local` for details.
 .. autofunction:: merge_contextvars
 .. autofunction:: clear_contextvars
 .. autofunction:: unbind_contextvars
+.. autofunction:: reset_contextvars
 
 
 .. _procs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,10 @@ nitpick_ignore = [
     ("py:class", "PlainFileObserver"),
     ("py:class", "structlog.threadlocal.TLLogger"),
     ("py:class", "TextIO"),
+    ("py:class", "TLLogger"),
+    ("py:class", "Token"),
     ("py:class", "traceback"),
+    ("py:class", "contextvars.Token"),
     ("py:class", "structlog._base.BoundLoggerBase"),
     ("py:class", "structlog.dev._Styles"),
     ("py:class", "structlog.types.EventDict"),
@@ -163,4 +166,4 @@ linkcheck_ignore = [
 # Twisted's trac tends to be slow
 linkcheck_timeout = 300
 
-intersphinx_mapping = {"https://docs.python.org/3": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/contextvars.rst
+++ b/docs/contextvars.rst
@@ -47,6 +47,7 @@ The general flow is:
    >>> # values:
    >>> clear_contextvars()
    >>> bind_contextvars(a=1, b=2)
+   {'a': <Token var=<ContextVar name='structlog_a' default=Ellipsis at ...> at ...>, 'b': <Token var=<ContextVar name='structlog_b' default=Ellipsis at ...> at ...>}
    >>> # Then use loggers as per normal
    >>> # (perhaps by using structlog.get_logger() to create them).
    >>> log.msg("hello")
@@ -61,3 +62,18 @@ The general flow is:
    >>> clear_contextvars()
    >>> log.msg("hi there")
    event='hi there' a=None
+
+
+If e.g. your request handler calls a helper function that needs to temporarily override some contextvars before restoring them back to their original values, you can use the :class:`~contextvars.contextvars.Token`\s returned by :func:`~structlog.contextvars.bind_contextvars` along with :func:`~structlog.contextvars.reset_contextvars` to accomplish this (much like how :meth:`contextvars.ContextVar.reset` works):
+
+.. code-block:: python
+
+    def foo():
+        bind_contextvars(a=1)
+        _helper()
+        log.msg("a is restored!")  # a=1
+
+    def _helper():
+        tokens = bind_contextvars(a=2)
+        log.msg("a is overridden")  # a=2
+        reset_contextvars(**tokens)

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -16,6 +16,7 @@ from structlog.contextvars import (
     get_contextvars,
     get_merged_contextvars,
     merge_contextvars,
+    reset_contextvars,
     unbind_contextvars,
 )
 
@@ -62,6 +63,30 @@ class TestContextvars:
             "c": 333,
             "d": 4,
         } == await event_loop.create_task(coro())
+
+    async def test_reset(self, event_loop):
+        """
+        reset_contextvars allows resetting contexvars to
+        previously-set values.
+        """
+
+        async def coro():
+            bind_contextvars(a=1)
+
+            assert {"a": 1} == get_contextvars()
+
+            await event_loop.create_task(nested_coro())
+
+        async def nested_coro():
+            tokens = bind_contextvars(a=2, b=3)
+
+            assert {"a": 2, "b": 3} == get_contextvars()
+
+            reset_contextvars(**tokens)
+
+            assert {"a": 1} == get_contextvars()
+
+        await event_loop.create_task(coro())
 
     async def test_nested_async_bind(self, event_loop):
         """


### PR DESCRIPTION
Update `structlog.contextvars.bind_contextvars()` to return a `Mapping[str, contextvar.Token]` corresponding to the results
of setting the requested contextvars.

This return value is suitable for use with the newly-added `structlog.contextvars.reset_contextvars()` function, which resets the requested contextvars to their previous values using the given Tokens.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!