### PR TITLE
Cease all use of Colorama on non-Windows systems.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Changes:
   This only works if ``format_exc_info`` is **absent** in the processor chain.
 - ``structlog.threadlocal.get_threadlocal()`` and ``structlog.contextvars.get_threadlocal()`` can now be used to get a copy of the current thread-local/context-local context that has been bound using ``structlog.threadlocal.bind_threadlocal()`` and ``structlog.contextvars.bind_contextvars()``.
 - ``structlog.threadlocal.get_merged_threadlocal(bl)`` and ``structlog.contextvars.get_merged_contextvars(bl)`` do the same, but also merge the context from a bound logger *bl*.
-
+- All use of ``colorama`` on non-Windows systems has been excised. Colors will now be enabled by default on non-Windows systems even if it's not installed, as it's not necessary on such systems.
 
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,8 @@ Changes:
   This only works if ``format_exc_info`` is **absent** in the processor chain.
 - ``structlog.threadlocal.get_threadlocal()`` and ``structlog.contextvars.get_threadlocal()`` can now be used to get a copy of the current thread-local/context-local context that has been bound using ``structlog.threadlocal.bind_threadlocal()`` and ``structlog.contextvars.bind_contextvars()``.
 - ``structlog.threadlocal.get_merged_threadlocal(bl)`` and ``structlog.contextvars.get_merged_contextvars(bl)`` do the same, but also merge the context from a bound logger *bl*.
-- All use of ``colorama`` on non-Windows systems has been excised. Colors will now be enabled by default on non-Windows systems even if it's not installed, as it's not necessary on such systems.
+- All use of ``colorama`` on non-Windows systems has been excised.
+  Colors will now be enabled by default on non-Windows systems even if colorama is not installed, as it's not necessary on such systems.
 
 ----
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -3,7 +3,7 @@ Development
 
 To make development a more pleasurable experience, ``structlog`` comes with the `structlog.dev` module.
 
-The highlight is `structlog.dev.ConsoleRenderer` that offers nicely aligned and colorful (requires the `colorama package <https://pypi.org/project/colorama/>`_ installed) console output.
+The highlight is `structlog.dev.ConsoleRenderer` that offers nicely aligned and colorful (requires the `colorama package <https://pypi.org/project/colorama/>`_ if on Windows) console output.
 If the `better-exceptions <https://github.com/Qix-/better-exceptions>`_ package is installed, it will also pretty-print exceptions with helpful contextual data.
 
 .. figure:: _static/console_renderer.png

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,7 @@ Here, ``structlog`` takes full advantage of its hopefully useful default setting
 - All keywords are formatted using `structlog.dev.ConsoleRenderer`.
   That in turn uses `repr` to serialize all values to strings.
   Thus, it's easy to add support for logging of your own objects\ [*]_.
-- If you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice `colors <development>`.
+- On Windows, if you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice `colors <development>`. Other OSes do not need colorama for nice colors.
 - If you have `better-exceptions <https://github.com/qix-/better-exceptions>`_ installed, exceptions will be rendered in colors and with additional helpful information.
 
 It should be noted that even in most complex logging setups the example would still look just like that thanks to `configuration`.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -34,7 +34,8 @@ Here, ``structlog`` takes full advantage of its hopefully useful default setting
 - All keywords are formatted using `structlog.dev.ConsoleRenderer`.
   That in turn uses `repr` to serialize all values to strings.
   Thus, it's easy to add support for logging of your own objects\ [*]_.
-- On Windows, if you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice `colors <development>`. Other OSes do not need colorama for nice colors.
+- On Windows, if you have `colorama <https://pypi.org/project/colorama/>`_ installed, it's rendered in nice `colors <development>`.
+  Other OSes do not need colorama for nice colors.
 - If you have `better-exceptions <https://github.com/qix-/better-exceptions>`_ installed, exceptions will be rendered in colors and with additional helpful information.
 
 It should be noted that even in most complex logging setups the example would still look just like that thanks to `configuration`.

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -23,7 +23,7 @@ from typing import (
 
 from ._log_levels import make_filtering_bound_logger
 from ._loggers import PrintLoggerFactory
-from .dev import ConsoleRenderer, _has_colorama, set_exc_info
+from .dev import ConsoleRenderer, _use_colors, set_exc_info
 from .processors import StackInfoRenderer, TimeStamper, add_log_level
 from .types import BindableLogger, Context, Processor, WrappedLogger
 
@@ -39,7 +39,7 @@ _BUILTIN_DEFAULT_PROCESSORS: Sequence[Processor] = [
     set_exc_info,
     TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
     ConsoleRenderer(
-        colors=_has_colorama and sys.stdout is not None and sys.stdout.isatty()
+        colors=_use_colors and sys.stdout is not None and sys.stdout.isatty()
     ),
 ]
 _BUILTIN_DEFAULT_CONTEXT_CLASS = cast(Type[Context], dict)

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -47,8 +47,6 @@ def _pad(s: str, length: int) -> str:
 
 
 if colorama is not None:
-    _has_colorama = True
-
     RESET_ALL = colorama.Style.RESET_ALL
     BRIGHT = colorama.Style.BRIGHT
     DIM = colorama.Style.DIM
@@ -60,21 +58,27 @@ if colorama is not None:
     GREEN = colorama.Fore.GREEN
     RED_BACK = colorama.Back.RED
 else:
-    _has_colorama = False
-
     # These are the same values as the colorama color codes. Redefining them
-    # here allows users to specify that they want color without having to 
+    # here allows users to specify that they want color without having to
     # install colorama, which is only supposed to be necessary in Windows.
-    RESET_ALL = '\033[0m'
-    BRIGHT = '\033[1m'
-    DIM = '\033[2m'
-    RED = '\033[31m'
-    BLUE = '\033[34m'
-    CYAN = '\033[36m'
-    MAGENTA = '\033[35m'
-    YELLOW = '\033[33m'
-    GREEN = '\033[32m'
-    RED_BACK = '\033[41m'
+    RESET_ALL = "\033[0m"
+    BRIGHT = "\033[1m"
+    DIM = "\033[2m"
+    RED = "\033[31m"
+    BLUE = "\033[34m"
+    CYAN = "\033[36m"
+    MAGENTA = "\033[35m"
+    YELLOW = "\033[33m"
+    GREEN = "\033[32m"
+    RED_BACK = "\033[41m"
+
+
+if _IS_WINDOWS:
+    # On Windows, use colors by default only if colorama is installed.
+    _use_colors = colorama is not None
+else:
+    # On other OSes, use colors by default.
+    _use_colors = True
 
 
 class _Styles(Protocol):
@@ -184,34 +188,36 @@ class ConsoleRenderer:
        `structlog.processors.format_exc_info` processor together with
        `ConsoleRenderer` anymore! It will keep working, but you can't have
        pretty exceptions and a warning will be raised if you ask for them.
+    .. versionchanged:: 21.3 The colors keyword now defaults to True on
+       non-Windows systems, and either True or False in Windows depending on
+       whether colorama is installed.
     """
 
     def __init__(
         self,
         pad_event: int = _EVENT_WIDTH,
-        colors: bool = _has_colorama,
+        colors: bool = _use_colors,
         force_colors: bool = False,
         repr_native_str: bool = False,
         level_styles: Optional[Styles] = None,
         pretty_exceptions: bool = (better_exceptions is not None),
     ):
-        self._force_colors = self._init_colorama = False
         styles: Styles
-        if colors is True:
-            if colorama is None:
-                raise SystemError(
-                    _MISSING.format(
-                        who=self.__class__.__name__ + " with `colors=True`",
-                        package="colorama",
-                    )
-                )
-
+        if colors:
             if _IS_WINDOWS:  # pragma: no cover
-                _init_colorama(self._force_colors)
-            else:
-                self._init_colorama = True
-                if force_colors:
-                    self._force_colors = True
+                # On Windows, we can't do colorful output without colorama.
+                if colorama is None:
+                    classname = self.__class__.__name__
+                    raise SystemError(
+                        _MISSING.format(
+                            who=classname + " with `colors=True`",
+                            package="colorama",
+                        )
+                    )
+                else:
+                    # Colorama must be init'd on Windows, but must NOT be
+                    # init'd on other OSes, because it can break colors.
+                    _init_colorama(force_colors)
 
             styles = _ColorfulStyles
         else:
@@ -251,10 +257,6 @@ class ConsoleRenderer:
         self, logger: WrappedLogger, name: str, event_dict: EventDict
     ) -> str:
 
-        # Initialize lazily to prevent import side-effects.
-        if self._init_colorama:
-            _init_colorama(self._force_colors)
-            self._init_colorama = False
         sio = StringIO()
 
         ts = event_dict.pop("timestamp", None)

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -73,7 +73,7 @@ else:
     RED_BACK = "\033[41m"
 
 
-if _IS_WINDOWS:
+if _IS_WINDOWS:  # pragma: no cover
     # On Windows, use colors by default only if colorama is installed.
     _use_colors = colorama is not None
 else:

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -62,9 +62,19 @@ if colorama is not None:
 else:
     _has_colorama = False
 
-    RESET_ALL = (
-        BRIGHT
-    ) = DIM = RED = BLUE = CYAN = MAGENTA = YELLOW = GREEN = RED_BACK = ""
+    # These are the same values as the colorama color codes. Redefining them
+    # here allows users to specify that they want color without having to 
+    # install colorama, which is only supposed to be necessary in Windows.
+    RESET_ALL = '\033[0m'
+    BRIGHT = '\033[1m'
+    DIM = '\033[2m'
+    RED = '\033[31m'
+    BLUE = '\033[34m'
+    CYAN = '\033[36m'
+    MAGENTA = '\033[35m'
+    YELLOW = '\033[33m'
+    GREEN = '\033[32m'
+    RED_BACK = '\033[41m'
 
 
 class _Styles(Protocol):

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -214,10 +214,13 @@ class ConsoleRenderer:
                             package="colorama",
                         )
                     )
+                # Colorama must be init'd on Windows, but must NOT be
+                # init'd on other OSes, because it can break colors.
+                if force_colors:
+                    colorama.deinit()
+                    colorama.init(strip=False)
                 else:
-                    # Colorama must be init'd on Windows, but must NOT be
-                    # init'd on other OSes, because it can break colors.
-                    _init_colorama(force_colors)
+                    colorama.init()
 
             styles = _ColorfulStyles
         else:
@@ -376,14 +379,6 @@ class ConsoleRenderer:
             "debug": styles.level_debug,
             "notset": styles.level_notset,
         }
-
-
-def _init_colorama(force: bool) -> None:
-    if force:
-        colorama.deinit()
-        colorama.init(strip=False)
-    else:
-        colorama.init()
 
 
 _SENTINEL = object()

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -26,7 +26,7 @@ class TestPad:
 
 @pytest.fixture(name="cr")
 def _cr():
-    return dev.ConsoleRenderer(colors=dev._has_colorama)
+    return dev.ConsoleRenderer(colors=dev._use_colors)
 
 
 @pytest.fixture(name="styles")
@@ -47,11 +47,14 @@ def _unpadded(styles):
 
 
 class TestConsoleRenderer:
-    @pytest.mark.skipif(dev._has_colorama, reason="Colorama must be missing.")
+    @pytest.mark.skipif(dev.colorama, reason="Colorama must be missing.")
+    @pytest.mark.skipif(
+        not dev._IS_WINDOWS, reason="Must be running on Windows."
+    )
     def test_missing_colorama(self):
         """
         ConsoleRenderer(colors=True) raises SystemError on initialization if
-        colorama is missing.
+        colorama is missing and _IS_WINDOWS is True.
         """
         with pytest.raises(SystemError) as e:
             dev.ConsoleRenderer(colors=True)
@@ -117,11 +120,11 @@ class TestConsoleRenderer:
         Stdlib levels are rendered aligned, in brackets, and color coded.
         """
         my_styles = dev.ConsoleRenderer.get_default_level_styles(
-            colors=dev._has_colorama
+            colors=dev._use_colors
         )
         my_styles["MY_OH_MY"] = my_styles["critical"]
         cr = dev.ConsoleRenderer(
-            colors=dev._has_colorama, level_styles=my_styles
+            colors=dev._use_colors, level_styles=my_styles
         )
 
         # this would blow up if the level_styles override failed
@@ -234,7 +237,7 @@ class TestConsoleRenderer:
         """
         `pad_event` parameter works.
         """
-        rv = dev.ConsoleRenderer(42, dev._has_colorama)(
+        rv = dev.ConsoleRenderer(42, dev._use_colors)(
             None, None, {"event": "test", "foo": "bar"}
         )
 
@@ -350,7 +353,7 @@ class TestConsoleRenderer:
         If force_colors is True, use colors even if the destination is non-tty.
         """
         cr = dev.ConsoleRenderer(
-            colors=dev._has_colorama, force_colors=dev._has_colorama
+            colors=dev._use_colors, force_colors=dev._use_colors
         )
 
         rv = cr(
@@ -374,7 +377,7 @@ class TestConsoleRenderer:
             + styles.reset
         ) == rv
 
-        assert not dev._has_colorama or dev._ColorfulStyles is cr._styles
+        assert not dev._use_colors or dev._ColorfulStyles is cr._styles
 
     @pytest.mark.parametrize("rns", [True, False])
     def test_repr_native_str(self, rns):


### PR DESCRIPTION
- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.rst` by hand.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [X] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

This PR was inspired by the frustration and confusion I suffered over the last week, dealing with figuring out why colored logging wan't working on my apps, despite everything seemingly having been configured properly. I eventually tracked it down to the `self.stream.isatty()` check on `colorama`'s `ansitowin32.py` file, line 92. Because my apps run in Docker containers, they don't log directly to a TTY, so it was returning False and forcing the ANSI-to-Win32 color code conversion, even though my apps run on Linux. This broke all the colors.

Yes, fixing this is what `ConsoleRenderer`'s `force_colors` kwarg appears to be for, but I was using an old version of `ConsoleRenderer` from before that was added, and didn't realize it.

Ultimately, though, my experience showed me that `colorama` isn't intended to be used on non-Windows systems at all (See https://github.com/tartley/colorama/issues/306). The *only* thing `colorama.init()` does is wrap `sys.stdout` and `sys.stderr` in the `AnsiToWin32` wrapper, which either does nothing on non-Win32 systems (if logging to a TTY) or is actively harmful (if logging to a file).

So I believe that `structlog` should change to avoid the use of `colorama` *at all* unless it's running on Windows. That's what this PR does. I made the following changes:

1. Replaced the blank color codes that `structlog` defines if `colorama` isn't installed with the actual raw ANSI color codes that `colorama` generates when one uses those constants.
2. Removed the lazy init code for `colorama`, since it isn't done lazily on Windows, and shouldn't be done on other OSes at all.
3. Fixed what appears to be a bug with the `force_colors` kwarg on Windows. The Windows init code was using `self._force_colors`, which was always `False` where that code was being called, even if the `force_colors` kwarg was `True`.
4. Changed the default value of `ConsoleRenderer`'s `colors` kwarg from "true if `colorama` is installed" to "True on Windows if `colorama` is installed, but always True on other OSes".
5. Updated the docs, tests, and changelog to reflect this change.

I hope I did this right... I don't contribute to GitHub all that often, but your "How to Contribute" guide was freaking **great** for helping give me the confidence that I was at least mostly doing this right. I ran `tox` and `pre-commit` for the first time ever, and it showed me some bugs in my original code, which I fixed before committing.

The one thing I'm a bit iffy on is the tests. I really just updated the "Make sure this crashes if `colors=True` is sent when colorama isn't installed" test doesn't get run unless it's running on Windows. I'm not really certain that's all that needs to change, or if that's even the right change.