### PR TITLE
Allow to preserve keys order in ConsoleRenderer. Related to #166

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- ``structlog.dev.ConsoleRenderer`` now has ``sort_keys`` boolean parameter which controls whether to sort keys when formatting keys output. `True` by default.
+  `#331 <https://github.com/hynek/structlog/pull/358>`_
 
 
 ----

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -235,6 +235,7 @@ class ConsoleRenderer:
         by default (rich_ taking precendence). You can also manually set it to
         `plain_traceback`, `better_traceback`, `rich_traceback`, or implement
         your own.
+    :param sort_keys: Whether to sort keys when formatting. `True` by default.
 
     Requires the colorama_ package if *colors* is `True` **on Windows**.
 
@@ -275,6 +276,7 @@ class ConsoleRenderer:
         repr_native_str: bool = False,
         level_styles: Optional[Styles] = None,
         exception_formatter: ExceptionFormatter = default_exception_formatter,
+        sort_keys: bool = True,
     ):
         styles: Styles
         if colors:
@@ -316,6 +318,7 @@ class ConsoleRenderer:
 
         self._repr_native_str = repr_native_str
         self._exception_formatter = exception_formatter
+        self._sort_keys = sort_keys
 
     def _repr(self, val: Any) -> str:
         """
@@ -383,6 +386,11 @@ class ConsoleRenderer:
         stack = event_dict.pop("stack", None)
         exc = event_dict.pop("exception", None)
         exc_info = event_dict.pop("exc_info", None)
+
+        event_dict_keys = event_dict.keys()
+        if self._sort_keys:
+            event_dict_keys = sorted(event_dict_keys)
+
         sio.write(
             " ".join(
                 self._styles.kv_key
@@ -392,7 +400,7 @@ class ConsoleRenderer:
                 + self._styles.kv_value
                 + self._repr(event_dict[key])
                 + self._styles.reset
-                for key in sorted(event_dict.keys())
+                for key in event_dict_keys
             )
         )
 

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -266,6 +266,7 @@ class ConsoleRenderer:
     .. versionchanged:: 21.2 The colors keyword now defaults to True on
        non-Windows systems, and either True or False in Windows depending on
        whether colorama is installed.
+    .. versionadded:: 21.3.0 *sort_keys*
     """
 
     def __init__(

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -4,6 +4,7 @@
 
 import pickle
 import sys
+
 from collections import OrderedDict
 from io import StringIO
 
@@ -212,11 +213,13 @@ class TestConsoleRenderer:
         """
         Key-value pairs go in original order to the end.
         """
-        cr = dev.ConsoleRenderer(
-            sort_keys=False
-        )
+        cr = dev.ConsoleRenderer(sort_keys=False)
 
-        rv = cr(None, None, OrderedDict([("event", "test"), ("key", "value"), ("foo", "bar")]))
+        rv = cr(
+            None,
+            None,
+            OrderedDict([("event", "test"), ("key", "value"), ("foo", "bar")]),
+        )
 
         assert (
             padded

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -5,7 +5,6 @@
 import pickle
 import sys
 
-from collections import OrderedDict
 from io import StringIO
 
 import pytest
@@ -218,7 +217,7 @@ class TestConsoleRenderer:
         rv = cr(
             None,
             None,
-            OrderedDict([("event", "test"), ("key", "value"), ("foo", "bar")]),
+            {"event": "test", "key": "value", "foo": "bar"},
         )
 
         assert (

--- a/tests/test_dev.py
+++ b/tests/test_dev.py
@@ -4,7 +4,7 @@
 
 import pickle
 import sys
-
+from collections import OrderedDict
 from io import StringIO
 
 import pytest
@@ -205,6 +205,35 @@ class TestConsoleRenderer:
             + "="
             + styles.kv_value
             + "value"
+            + styles.reset
+        ) == rv
+
+    def test_key_values_unsorted(self, styles, padded):
+        """
+        Key-value pairs go in original order to the end.
+        """
+        cr = dev.ConsoleRenderer(
+            sort_keys=False
+        )
+
+        rv = cr(None, None, OrderedDict([("event", "test"), ("key", "value"), ("foo", "bar")]))
+
+        assert (
+            padded
+            + styles.kv_key
+            + "key"
+            + styles.reset
+            + "="
+            + styles.kv_value
+            + "value"
+            + styles.reset
+            + " "
+            + styles.kv_key
+            + "foo"
+            + styles.reset
+            + "="
+            + styles.kv_value
+            + "bar"
             + styles.reset
         ) == rv
 


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
