### PR TITLE
Get TimeStamper working properly if datetime module is mocked before its instantiation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Changes:
 
 - ``structlog.dev.ConsoleRenderer`` now has ``sort_keys`` boolean parameter that allows to disable the sorting of keys on output.
   `#358 <https://github.com/hynek/structlog/pull/358>`_
-
+- ``structlog.processors.TimeStamper`` now works well with FreezeGun even when it gets applied before the loggers are configured.
+  `#364 <https://github.com/hynek/structlog/pull/364>`_
 
 ----
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -365,11 +365,11 @@ def _make_stamper(
 
         if utc:
             return stamper_iso_utc
-        else:
-            return stamper_iso_local
+
+        return stamper_iso_local
 
     def stamper_fmt(event_dict: EventDict) -> EventDict:
-        event_dict[key] = now().strftime(fmt)
+        event_dict[key] = now().strftime(fmt)  # type: ignore
 
         return event_dict
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -333,7 +333,17 @@ def _make_stamper(
     if fmt is None and not utc:
         raise ValueError("UNIX timestamps are always UTC.")
 
-    now = getattr(datetime.datetime, "utcnow" if utc else "now")
+    now: Callable[[], datetime.datetime]
+
+    if utc:
+
+        def now() -> datetime.datetime:
+            return datetime.datetime.utcnow()
+
+    else:
+
+        def now() -> datetime.datetime:
+            return datetime.datetime.now()
 
     if fmt is None:
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -274,6 +274,22 @@ class TestTimeStamper:
             None, None, {}
         )
 
+    @pytest.mark.parametrize(
+        ("utc", "expect"),
+        [
+            (True, "1980-03-25T16:00:00Z"),
+            (False, "1980-03-25T17:00:00"),
+        ],
+    )
+    def test_apply_freezegun_after_instantiation(self, utc, expect):
+        """
+        Instantiate TimeStamper after mocking datetime
+        """
+        ts = TimeStamper(fmt="iso", utc=utc)
+        with freeze_time("1980-03-25 16:00:00", tz_offset=1):
+            d = ts(None, None, {})
+            assert expect == d["timestamp"]
+
 
 class TestFormatExcInfo:
     @pytest.mark.parametrize("ei", [False, None, ""])


### PR DESCRIPTION
## Summary

Because the reference to either `datetime.now()` or `datetime.utcnow()` is retrieved during `TimeStamper` is being created, it gets into trouble when FreezeGun or any similar mechanism that patches `datetime` module is applied before the instantiation.  This patchs proposes a modification to it so that the invocation to the "now" function will always be done with dereferences from the datetime module object, albeit the slight possible performance penalty.

## Checklist

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
