### PR TITLE
fix __doc__ is None in optimized mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Fixed ``structlog`` when running in optimized mode (PYTHONOPTIMIZE=2).
+- Fixed import when running in optimized mode (``PYTHONOPTIMIZE=2``).
+   `#373 <https://github.com/hynek/structlog/pull/373>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Fixed ``structlog`` when running in optimized mode (PYTHONOPTIMIZE=2). 
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Fixed ``structlog`` when running in optimized mode (PYTHONOPTIMIZE=2). 
+- Fixed ``structlog`` when running in optimized mode (PYTHONOPTIMIZE=2).
 
 
 ----

--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -46,10 +46,10 @@ __version__ = "21.4.0.dev0"
 
 __title__ = "structlog"
 if __doc__ is None:
-    __description__ = "" 
-else: 
+    __description__ = ""
+else:
     __description__ = __doc__.strip()
-    
+
 __uri__ = "https://www.structlog.org/"
 
 __author__ = "Hynek Schlawack"

--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -46,7 +46,8 @@ __version__ = "21.4.0.dev0"
 
 __title__ = "structlog"
 if __doc__ is None:
-    __description__ = ""
+    # __doc__ is None when running with PYTHONOPTIMIZE=2 / -OO
+    __description__ = ""  # pragma: no cover
 else:
     __description__ = __doc__.strip()
 

--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -45,7 +45,11 @@ except ImportError:
 __version__ = "21.4.0.dev0"
 
 __title__ = "structlog"
-__description__ = __doc__.strip()
+if __doc__ is None:
+    __description__ = "" 
+else: 
+    __description__ = __doc__.strip()
+    
 __uri__ = "https://www.structlog.org/"
 
 __author__ = "Hynek Schlawack"


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.structlog.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

Not sure how a specific test can be launched with this env variable (PYTHONOPTIMIZE=2)