### PR TITLE
Add LogfmtRenderer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Changes:
 ^^^^^^^^
 
 - Added the ``structlog.processors.LogfmtRenderer`` processor to render log lines using the `logfmt <https://brandur.org/logfmt>`_ format.
+  `#376 <https://github.com/hynek/structlog/pull/376>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added the ``structlog.processors.LogfmtRenderer`` processor to render log lines using the `logfmt <https://brandur.org/logfmt>`_ format.
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -237,11 +237,11 @@ Please see :doc:`thread-local` for details.
    .. doctest::
 
       >>> from structlog.processors import LogfmtRenderer
-      >>> event_dict = {"a": 42, "b": [1, 2, 3]}
+      >>> event_dict = {"a": 42, "b": [1, 2, 3], "flag": True}
       >>> LogfmtRenderer(sort_keys=True)(None, None, event_dict)
-      'a=42 b="[1, 2, 3]"'
-      >>> LogfmtRenderer(key_order=["b", "a"])(None, None, event_dict)
-      'b="[1, 2, 3]" a=42'
+      'a=42 b="[1, 2, 3]" flag'
+      >>> LogfmtRenderer(key_order=["b", "a"], bool_as_flag=False)(None, None, event_dict)
+      'b="[1, 2, 3]" a=42 flag=true'
 
 .. autofunction:: add_log_level
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -237,10 +237,10 @@ Please see :doc:`thread-local` for details.
    .. doctest::
 
       >>> from structlog.processors import LogfmtRenderer
-      >>> LogfmtRenderer(sort_keys=True)(None, None, {"a": 42, "b": [1, 2, 3]})
+      >>> event_dict = {"a": 42, "b": [1, 2, 3]}
+      >>> LogfmtRenderer(sort_keys=True)(None, None, event_dict)
       'a=42 b="[1, 2, 3]"'
-      >>> LogfmtRenderer(key_order=["b", "a"])(None, None,
-      ...                                      {"a": 42, "b": [1, 2, 3]})
+      >>> LogfmtRenderer(key_order=["b", "a"])(None, None, event_dict)
       'b="[1, 2, 3]" a=42'
 
 .. autofunction:: add_log_level

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -232,6 +232,16 @@ Please see :doc:`thread-local` for details.
       ...                                       {"a": 42, "b": [1, 2, 3]})
       'b=[1, 2, 3] a=42'
 
+.. autoclass:: LogfmtRenderer
+
+   .. doctest::
+
+      >>> from structlog.processors import LogfmtRenderer
+      >>> LogfmtRenderer(sort_keys=True)(None, None, {"a": 42, "b": [1, 2, 3]})
+      'a=42 b="[1, 2, 3]"'
+      >>> LogfmtRenderer(key_order=["b", "a"])(None, None,
+      ...                                      {"a": 42, "b": [1, 2, 3]})
+      'b="[1, 2, 3]" a=42'
 
 .. autofunction:: add_log_level
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "structlog"
 authors = [{name = "Hynek Schlawack", email = "hs@ox.cx"}]
 dynamic = ["version", "description"]
 requires-python = ">=3.6"
-dependencies = ["typing-extensions; python_version<'3.8'"]
+dependencies = ["typing-extensions; python_version<'3.8'", "logfmt>=0.4"]
 license = { file = "LICENSE" }
 keywords = ["logging", "structured", "structure", "log"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "structlog"
 authors = [{name = "Hynek Schlawack", email = "hs@ox.cx"}]
 dynamic = ["version", "description"]
 requires-python = ">=3.6"
-dependencies = ["typing-extensions; python_version<'3.8'", "logfmt>=0.4"]
+dependencies = ["typing-extensions; python_version<'3.8'"]
 license = { file = "LICENSE" }
 keywords = ["logging", "structured", "structure", "log"]
 classifiers = [

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -102,7 +102,7 @@ class KeyValueRenderer:
 class LogfmtRenderer:
     """
     Render ``event_dict`` using the logfmt_ format.
-    
+
     .. _logfmt: https://brandur.org/logfmt
 
     :param sort_keys: Whether to sort keys when formatting.

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -126,9 +126,7 @@ class LogfmtRenderer:
     ) -> str:
 
         try:
-            return next(
-                logfmt.format(dict(self._ordered_items(event_dict)))
-            )
+            return next(logfmt.format(dict(self._ordered_items(event_dict))))
         except StopIteration:
             return ""
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -101,7 +101,9 @@ class KeyValueRenderer:
 
 class LogfmtRenderer:
     """
-    Render ``event_dict`` using the logfmt format.
+    Render ``event_dict`` using the logfmt_ format.
+    
+    .. _logfmt: https://brandur.org/logfmt
 
     :param sort_keys: Whether to sort keys when formatting.
     :param key_order: List of keys that should be rendered in this exact
@@ -137,9 +139,9 @@ def _items_sorter(
     drop_missing: bool,
 ) -> Callable[[EventDict], List[Tuple[str, Any]]]:
     """
-    Return a function to sort items from an `event_dict`.
+    Return a function to sort items from an ``event_dict``.
 
-    See :class:`KeyValueRenderer` for an explanation of the parameters.
+    See `KeyValueRenderer` for an explanation of the parameters.
     """
     # Use an optimized version for each case.
     if key_order and sort_keys:

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -101,12 +101,12 @@ class KeyValueRenderer:
 
 class LogfmtRenderer:
     """
-    Render ``event_dict`` using the `logfmt <https://brandur.org/logfmt>`_ format.
+    Render ``event_dict`` using the logfmt format.
 
     :param sort_keys: Whether to sort keys when formatting.
     :param key_order: List of keys that should be rendered in this exact
-        order. Missing keys are rendered with empty values, extra keys depending on
-        *sort_keys* and the dict class.
+        order. Missing keys are rendered with empty values, extra keys
+        depending on *sort_keys* and the dict class.
     :param drop_missing: When ``True``, extra keys in *key_order* will be
         dropped rather than rendered with empty values.
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -206,6 +206,14 @@ class TestLogfmtRenderer:
 
         assert isinstance(rv, str)
 
+    def test_empty_event_dict(self):
+        """
+        Empty event dict renders as empty string.
+        """
+        rv = LogfmtRenderer()(None, None, {})
+
+        assert "" == rv
+
 
 class TestJSONRenderer:
     def test_renders_json(self, event_dict):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -193,7 +193,10 @@ class TestLogfmtRenderer:
             drop_missing=True,
         )(None, None, event_dict)
 
-        assert r'y="test" b="[3, 4]" a="<A(\o/)>" z="(1, 2)" x=7 A="A" B="B"' == rv
+        assert (
+            r'y="test" b="[3, 4]" a="<A(\o/)>" z="(1, 2)" x=7 A="A" B="B"'
+            == rv
+        )
 
     def test_random_order(self, event_dict):
         """
@@ -202,8 +205,6 @@ class TestLogfmtRenderer:
         rv = LogfmtRenderer()(None, None, event_dict)
 
         assert isinstance(rv, str)
-
-
 
 
 class TestJSONRenderer:

--- a/tests/typing_examples.py
+++ b/tests/typing_examples.py
@@ -185,6 +185,24 @@ structlog.configure(
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
+        structlog.processors.LogfmtRenderer(),
+    ],
+    context_class=dict,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
         structlog.processors.JSONRenderer(),
     ],
     context_class=dict,


### PR DESCRIPTION
# Summary

This PR adds a `LogfmtRenderer` processor to format log lines in the [logfmt](https://brandur.org/logfmt) format.

The core of the work is done by the [`logfmt`](https://pypi.org/project/logfmt/) library, which is added as global dependency. Or should this be changed to feature-based optional?

Refactored the code in `KeyValueRenderer` to share the `sort_keys`/`key_order`/`drop_missing` logic. Tests are directly adapted from `KeyValueRenderer`.

Closes #322 


# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
