### PR TITLE
Add `ExtraAdder` Processor function to `structlog.stdlib`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,8 +39,8 @@ Changes:
 
 - Added the ``structlog.processors.LogfmtRenderer`` processor to render log lines using the `logfmt <https://brandur.org/logfmt>`_ format.
   `#376 <https://github.com/hynek/structlog/pull/376>`_
-- Added ``structlog.stdlib.add_extra`` processor that adds extra ``logging.LogRecord`` keys to the event dictionary.
-  This function is useful for adding data passed in the ``extra`` parameter of the ``logging`` module's log methods to the event dictionary.
+- Added the ``structlog.stdlib.ExtraAdder`` processor that adds extra attributes of ``logging.LogRecord`` objects to the event dictionary.
+  This processor can be used for adding data passed in the ``extra`` parameter of the `logging` module's log methods to the event dictionary.
   `#377 <https://github.com/hynek/structlog/pull/377>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@ Changes:
 
 - Added the ``structlog.processors.LogfmtRenderer`` processor to render log lines using the `logfmt <https://brandur.org/logfmt>`_ format.
   `#376 <https://github.com/hynek/structlog/pull/376>`_
+- Added ``structlog.stdlib.add_extra`` processor that adds extra ``logging.LogRecord`` keys to the event dictionary.
+  This function is useful for adding data passed in the ``extra`` parameter of the ``logging`` module's log methods to the event dictionary.
+  `#377 <https://github.com/hynek/structlog/pull/377>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -302,7 +302,7 @@ Please see :doc:`thread-local` for details.
 
 .. autofunction:: add_logger_name
 
-.. autofunction:: add_extra
+.. autofunction:: ExtraAdder
 
 .. autoclass:: PositionalArgumentsFormatter
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -302,6 +302,8 @@ Please see :doc:`thread-local` for details.
 
 .. autofunction:: add_logger_name
 
+.. autofunction:: add_extra
+
 .. autoclass:: PositionalArgumentsFormatter
 
 .. autoclass:: ProcessorFormatter

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -76,10 +76,10 @@ Processors
 `add_logger_name`:
    Adds the name of the logger to the event dictionary under the key ``logger``.
 
-`add_extra`:
-   Add extra `logging.LogRecord` keys to the event dictionary.
+`ExtraAdder`:
+   Add extra attributes of `logging.LogRecord` objects to the event dictionary.
 
-   This function is useful for adding data passed in the ``extra`` parameter of the `logging` module's log methods to the event dictionary.
+   This processor can be used for adding data passed in the ``extra`` parameter of the `logging` module's log methods to the event dictionary.
 
 :func:`~structlog.stdlib.add_log_level`:
    Adds the log level to the event dictionary under the key ``level``.
@@ -418,10 +418,10 @@ For example, to use the standard library's `logging.config.dictConfig` to log co
         # Add the log level and a timestamp to the event_dict if the log entry
         # is not from structlog.
         structlog.stdlib.add_log_level,
-        # Add extra LogRecord keys to the event dictionary so that values
-        # passed in the extra parameter of log methods are added to the event
-        # dictionary.
-        structlog.stdlib.add_extra,
+        # Add extra attributes of LogRecord objects to the event dictionary
+        # so that values passed in the extra parameter of log methods pass
+        # through to log output.
+        structlog.stdlib.ExtraAdder(),
         timestamper,
     ]
 

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -76,6 +76,11 @@ Processors
 `add_logger_name`:
    Adds the name of the logger to the event dictionary under the key ``logger``.
 
+`add_extra`:
+   Add extra `logging.LogRecord` keys to the event dictionary.
+
+   This function is useful for adding data passed in the ``extra`` parameter of the `logging` module's log methods to the event dictionary.
+
 :func:`~structlog.stdlib.add_log_level`:
    Adds the log level to the event dictionary under the key ``level``.
 
@@ -413,6 +418,10 @@ For example, to use the standard library's `logging.config.dictConfig` to log co
         # Add the log level and a timestamp to the event_dict if the log entry
         # is not from structlog.
         structlog.stdlib.add_log_level,
+        # Add extra LogRecord keys to the event dictionary so that values
+        # passed in the extra parameter of log methods are added to the event
+        # dictionary.
+        structlog.stdlib.add_extra,
         timestamper,
     ]
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -18,6 +18,7 @@ from functools import partial
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Iterable,
     List,
@@ -44,7 +45,7 @@ __all__ = [
     "add_log_level_number",
     "add_log_level",
     "add_logger_name",
-    "add_extra",
+    "ExtraAdder",
     "BoundLogger",
     "filter_by_level",
     "get_logger",
@@ -666,35 +667,35 @@ def add_logger_name(
     return event_dict
 
 
-_BLANK_LOGRECORD = logging.LogRecord(
+_LOG_RECORD_KEYS = logging.LogRecord(
     "name", 0, "pathname", 0, "msg", tuple(), None
-)
+).__dict__.keys()
 
 
 class ExtraAdder:
     """
-    Add extra `logging.LogRecord` attributes to the event dictionary.
+    Add extra attributes of `logging.LogRecord` objects to the event
+    dictionary.
 
-    This processor is useful for adding data passed in the ``extra`` parameter
-    of the `logging` module's log methods to the event dictionary.
+    This processor can be used for adding data passed in the ``extra``
+    parameter of the `logging` module's log methods to the event dictionary.
 
-    :param allow: An optional list of keys to allow to pass through from
-        `logging.LogRecord` objects to event dictionaries.
+    :param allow: An optional collection of attributes that, if present in
+        `logging.LogRecord` objects, will be copied to event dictionaries.
 
-        If `allow` is set to None, then all extra `log`
+        If ``allow`` is None all attributes of `logging.LogRecord` objects that
+        do not exist on a standard `logging.LogRecord` object will be copied to
+        event dictionaries.
 
     .. versionadded:: 21.5.0
     """
-    __slots__ = ["_allow", "_copier"]
 
-    def __init__(self, allow: Optional[Sequence[str]] = None) -> None:
-        self._allow = allow
+    __slots__ = ["_copier"]
+
+    def __init__(self, allow: Optional[Collection[str]] = None) -> None:
         self._copier: Callable[[EventDict, logging.LogRecord], None]
-        if self._allow is not None:
-            # this is to convince mypy that the value being passed as the first
-            # argument to _copy_allowed is in fact not an optional.
-            _allow = self._allow
-            self._copier = functools.partial(self._copy_allowed, _allow)
+        if allow is not None:
+            self._copier = functools.partial(self._copy_allowed, [*allow])
         else:
             self._copier = self._copy_all
 
@@ -711,19 +712,20 @@ class ExtraAdder:
         cls, event_dict: EventDict, record: logging.LogRecord
     ) -> None:
         for key, value in record.__dict__.items():
-            if key not in _BLANK_LOGRECORD.__dict__:
+            if key not in _LOG_RECORD_KEYS:
                 event_dict[key] = value
 
     @classmethod
     def _copy_allowed(
         cls,
-        allow: Sequence[str],
+        allow: Collection[str],
         event_dict: EventDict,
         record: logging.LogRecord,
     ) -> None:
         for key in allow:
             if key in record.__dict__:
                 event_dict[key] = record.__dict__[key]
+
 
 def render_to_log_kwargs(
     _: logging.Logger, __: str, event_dict: EventDict

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -664,6 +664,30 @@ def add_logger_name(
     return event_dict
 
 
+_BLANK_LOGRECORD = logging.LogRecord(
+    "name", 0, "pathname", 0, "msg", tuple(), None
+)
+
+
+def add_extra(
+    logger: logging.Logger, method_name: str, event_dict: EventDict
+) -> EventDict:
+    """
+    Add extra `logging.LogRecord` keys to the event dictionary.
+
+    This function is useful for adding data passed in the ``extra`` parameter
+    of the `logging` module's log methods to the event dictionary.
+
+    .. versionadded:: 21.5.0
+    """
+    record: Optional[logging.LogRecord] = event_dict.get("_record")
+    if record is not None:
+        for key, value in record.__dict__.items():
+            if key not in _BLANK_LOGRECORD.__dict__:
+                event_dict[key] = value
+    return event_dict
+
+
 def render_to_log_kwargs(
     _: logging.Logger, __: str, event_dict: EventDict
 ) -> EventDict:

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -43,6 +43,7 @@ __all__ = [
     "add_log_level_number",
     "add_log_level",
     "add_logger_name",
+    "add_extra",
     "BoundLogger",
     "filter_by_level",
     "get_logger",

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -485,7 +485,7 @@ class TestAddExtra:
         record.__dict__.update(extra)
         event_dict = {"_record": record}
         event_dict_out = add_extra(None, None, event_dict)
-        assert event_dict_out == {**event_dict, **extra}
+        assert {**event_dict, **extra} == event_dict_out
 
     def test_add_extra_e2e(self):
         """

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -91,7 +91,14 @@ structlog.configure(
 
 formatter = structlog.stdlib.ProcessorFormatter(
     processor=structlog.dev.ConsoleRenderer(),
-    foreign_pre_chain=[*structlog.stdlib.add_extra, shared_processors],
+    foreign_pre_chain=[
+        structlog.stdlib.ExtraAdder(),
+        structlog.stdlib.ExtraAdder(allow=None),
+        structlog.stdlib.ExtraAdder(None),
+        structlog.stdlib.ExtraAdder(allow=["k1", "k2"]),
+        structlog.stdlib.ExtraAdder({"k1", "k2"}),
+        *shared_processors,
+    ],
 )
 
 

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -91,7 +91,7 @@ structlog.configure(
 
 formatter = structlog.stdlib.ProcessorFormatter(
     processor=structlog.dev.ConsoleRenderer(),
-    foreign_pre_chain=shared_processors,
+    foreign_pre_chain=[*structlog.stdlib.add_extra, shared_processors],
 )
 
 


### PR DESCRIPTION
# Summary

Added the `structlog.stdlib.ExtraAdder` processor that adds extra attributes of `logging.LogRecord` objects to the event dictionary.
  This processor can be used for adding data passed in the `extra` parameter of the `logging` module's log methods to the event dictionary.

Fixes #209

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [changelog](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
