### PR TITLE
Add an explaining comment to ExtraAdder

### DIFF
--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -695,6 +695,9 @@ class ExtraAdder:
     def __init__(self, allow: Optional[Collection[str]] = None) -> None:
         self._copier: Callable[[EventDict, logging.LogRecord], None]
         if allow is not None:
+            # The contents of allow is copied to a new list so that changes to
+            # the list passed into the constructor does not change the
+            # behaviour of this processor.
             self._copier = functools.partial(self._copy_allowed, [*allow])
         else:
             self._copier = self._copy_all


### PR DESCRIPTION
# Summary

The comment explains the copying of the `allow` parameter's content to a new list.


# Pull Request Check List

This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
- [x] Consider granting push permissions to the PR branch, so maintainers can fix minor issues themselves without pestering you.

If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
