### PR TITLE
Fix spelling mistakes in comments

### DIFF
--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -233,7 +233,7 @@ class ConsoleRenderer:
         `ConsoleRenderer.get_default_level_styles`
     :param exception_formatter: A callable to render ``exc_infos``. If rich_
         or better-exceptions_ are installed, they are used for pretty-printing
-        by default (rich_ taking precendence). You can also manually set it to
+        by default (rich_ taking precedence). You can also manually set it to
         `plain_traceback`, `better_traceback`, `rich_traceback`, or implement
         your own.
     :param sort_keys: Whether to sort keys when formatting. `True` by default.

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -383,7 +383,7 @@ class AsyncBoundLogger:
 
     sync_bl: BoundLogger
 
-    # Blantant lie, we use a property for _context. Need this for Protocol
+    # Blatant lie, we use a property for _context. Need this for Protocol
     # though.
     _context: Context
 


### PR DESCRIPTION


# Summary

Fixed spelling mistakes in comment

Picked it up running:

```bash
pylint \
  --disable all \
  --enable spelling \
  --spelling-dict en_US \
  --spelling-private-dict-file=~/.config/pylint-dict \
  src/structlog/stdlib.py
```


# Pull Request Check List

This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
- [x] Consider granting push permissions to the PR branch, so maintainers can fix minor issues themselves without pestering you.

If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
