### PR TITLE
Add CallsiteParameterAdder processor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Changes:
 - Added the ``structlog.stdlib.ExtraAdder`` processor that adds extra attributes of ``logging.LogRecord`` objects to the event dictionary.
   This processor can be used for adding data passed in the ``extra`` parameter of the ``logging`` module's log methods to the event dictionary.
   `#377 <https://github.com/hynek/structlog/pull/377>`_
+- Added the ``structlog.processor.CallsiteParameterAdder`` processor that adds parameters of the callsite that an event dictionary orginated from to the event dictionary.
+  This processor can be used to enrich events dictionaries with information such as the function name, line number and filename that an event dictionary orignated from.
+  `#380 <https://github.com/hynek/structlog/pull/380>`_
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -279,8 +279,6 @@ Please see :doc:`thread-local` for details.
 .. autoclass:: CallsiteParameter
    :members:
 
-.. autodata:: CALLSITE_PARAMETERS
-
 .. autoclass:: CallsiteParameterAdder
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -276,6 +276,13 @@ Please see :doc:`thread-local` for details.
       >>> TimeStamper(fmt="%Y", key="year")(None, None, {})  # doctest: +SKIP
       {'year': '2013'}
 
+.. autoclass:: CallsiteParameter
+   :members:
+
+.. autodata:: CALLSITE_PARAMETERS
+
+.. autoclass:: CallsiteParameterAdder
+
 
 `structlog.stdlib` Module
 -------------------------

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -166,6 +166,12 @@ A basic configuration to output structured logs in JSON format looks like this:
             structlog.processors.format_exc_info,
             # If some value is in bytes, decode it to a unicode str.
             structlog.processors.UnicodeDecoder(),
+            # Add callsite parameters.
+            structlog.processors.CallsiteParameterAdder(
+                CallsiteParameter.FILENAME,
+                CallsiteParameter.FUNC_NAME,
+                CallsiteParameter.LINENO,
+            ),
             # Render the final event dict as JSON.
             structlog.processors.JSONRenderer()
         ],

--- a/src/structlog/_utils.py
+++ b/src/structlog/_utils.py
@@ -33,7 +33,7 @@ def until_not_interrupted(f: Callable[..., Any], *args: Any, **kw: Any) -> Any:
 def get_processname() -> str:
     # based on code from
     # https://github.com/python/cpython/blob/313f92a57bc3887026ec16adb536bb2b7580ce47/Lib/logging/__init__.py#L342-L352
-    processname = "MainProcess"
+    processname = "n/a"
     mp: Any = sys.modules.get("multiprocessing")
     if mp is not None:
         # Errors may occur if multiprocessing has not finished loading

--- a/src/structlog/_utils.py
+++ b/src/structlog/_utils.py
@@ -8,6 +8,7 @@ Generic utilities.
 """
 
 import errno
+import sys
 
 from typing import Any, Callable
 
@@ -27,3 +28,19 @@ def until_not_interrupted(f: Callable[..., Any], *args: Any, **kw: Any) -> Any:
             if e.args[0] == errno.EINTR:
                 continue
             raise
+
+
+def get_processname() -> str:
+    # based on code from
+    # https://github.com/python/cpython/blob/313f92a57bc3887026ec16adb536bb2b7580ce47/Lib/logging/__init__.py#L342-L352
+    processname = "MainProcess"
+    mp: Any = sys.modules.get("multiprocessing")
+    if mp is not None:
+        # Errors may occur if multiprocessing has not finished loading
+        # yet - e.g. if a custom import hook causes third-party code
+        # to run when multiprocessing calls import.
+        try:
+            processname = mp.current_process().name
+        except Exception:
+            pass
+    return processname

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -545,7 +545,7 @@ class StackInfoRenderer:
         return event_dict
 
 
-class CallsiteParameter(str, enum.Enum):
+class CallsiteParameter(enum.Enum):
     """
     Callsite parameters that can be added to an event dictionary with the
     `structlog.processors.CallsiteParameterAdder` processor class.
@@ -613,7 +613,7 @@ class CallsiteParameterAdder:
         When used with `structlog.stdlib.ProcessorFormatter` the most efficient
         configuration is to either use this processor in ``foreign_pre_chain``
         of `structlog.stdlib.ProcessorFormatter` and in ``processors`` of
-        `structlog.configure`, or to use it in ``processor`` of
+        `structlog.configure`, or to use it in ``processors`` of
         `structlog.stdlib.ProcessorFormatter` without using it in
         ``processors`` of `structlog.configure` and ``foreign_pre_chain`` of
         `structlog.stdlib.ProcessorFormatter`.
@@ -621,8 +621,8 @@ class CallsiteParameterAdder:
     .. versionadded:: 21.5.0
     """
 
-    _handlers: Dict[
-        CallsiteParameter, Callable[[str, inspect.Traceback], Any]
+    _handlers: ClassVar[
+        Dict[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
     ] = {
         CallsiteParameter.PATHNAME: (
             lambda module, frame_info: frame_info.filename
@@ -664,7 +664,7 @@ class CallsiteParameterAdder:
         CallsiteParameter.PROCESS_NAME: "processName",
     }
 
-    _all_parameters: Set[CallsiteParameter] = set(CallsiteParameter)
+    _all_parameters: ClassVar[Set[CallsiteParameter]] = set(CallsiteParameter)
 
     class _RecordMapping(NamedTuple):
         event_dict_key: str

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -8,18 +8,27 @@ Processors useful regardless of the logging framework.
 """
 
 import datetime
+import enum
+import inspect
 import json
+import logging
 import operator
+import os
 import sys
+import threading
 import time
 
 from typing import (
     Any,
     Callable,
+    ClassVar,
+    Collection,
     Dict,
     List,
+    NamedTuple,
     Optional,
     Sequence,
+    Set,
     TextIO,
     Tuple,
     Union,
@@ -31,6 +40,7 @@ from ._frames import (
     _format_stack,
 )
 from ._log_levels import _NAME_TO_LEVEL, add_log_level
+from ._utils import get_processname
 from .types import EventDict, ExcInfo, WrappedLogger
 
 
@@ -45,6 +55,9 @@ __all__ = [
     "format_exc_info",
     "ExceptionPrettyPrinter",
     "StackInfoRenderer",
+    "CALLSITE_PARAMETERS",
+    "CallsiteParameter",
+    "CallsiteParameterAdder",
 ]
 
 
@@ -530,4 +543,196 @@ class StackInfoRenderer:
                 _find_first_app_frame_and_name()[0]
             )
 
+        return event_dict
+
+
+class CallsiteParameter(str, enum.Enum):
+    """
+    Callsite parameters that can be added to an event dictionary with the
+    `structlog.processors.CallsiteParameterAdder` processor class.
+
+    The string values of the members of this enum will be used as the keys for
+    the callsite parameters in the event dictionary.
+
+    .. versionadded:: 21.5.0
+    """
+
+    #: The full path to the python source file of the callsite.
+    PATHNAME = "pathname"
+    #: The basename part of the full path to the python source file of the
+    #: callsite.
+    FILENAME = "filename"
+    #: The python module the callsite was in. This mimicks the module attribute
+    #: of `logging.LogRecord` objects and will be the basename, without
+    #: extension, of the full path to the python source file of the callsite.
+    MODULE = "module"
+    #: The name of the function that the callsite was in.
+    FUNC_NAME = "func_name"
+    #: The line number of the callsite.
+    LINENO = "lineno"
+    #: The ID of the thread the callsite was executed in.
+    THREAD = "thread"
+    #: The name of the thread the callsite was executed in.
+    THREAD_NAME = "thread_name"
+    #: The ID of the process the callsite was executed in.
+    PROCESS = "process"
+    #: The name of the process the callsite was executed in.
+    PROCESS_NAME = "process_name"
+
+
+#: A set of all `CallsiteParameter` enum members.
+#:
+#: .. versionadded:: 21.5.0
+CALLSITE_PARAMETERS: Set[CallsiteParameter] = set(CallsiteParameter)
+
+
+class CallsiteParameterAdder:
+    """
+    Adds parameters of the callsite that an event dictionary originated from to
+    the event dictionary. This processor can be used to enrich events
+    dictionaries with information such as the function name, line number and
+    filename that an event dictionary originated from.
+
+    .. warning::
+        This processor cannot detect the correct callsite for invocation of
+        async functions.
+
+    If the event dictionary has an embedded `logging.LogRecord` object and did
+    not originate from `structlog` then the callsite information will be
+    determined from the `logging.LogRecord` object. For event dictionaries
+    without an embedded `logging.LogRecord` object the callsite will be
+    determined from stack trace, ignoring all intra-structlog calls and calls
+    from the `logging` module and frames that from module names starting with
+    values in ``additional_ignores``, if it is specified.
+
+    The keys used for various callsite parameters in the event dictionary are
+    the string values of `CallsiteParameter` enum members.
+
+    :param parameters:
+        A collection of `CallsiteParameter` values that should be added to the
+        event dictionary.
+
+    :param additional_ignores:
+        Additional names with which the a frame's module name must not start.
+
+    .. note::
+        When used with `structlog.stdlib.ProcessorFormatter` the most
+        efficient configuration is to either use this processor in
+        ``foreign_pre_chain`` of `structlog.stdlib.ProcessorFormatter` and in
+        ``processors`` of `structlog.configure`, or to use it in ``processor``
+        of `structlog.stdlib.ProcessorFormatter` without using it in
+        ``processors`` of `structlog.configure` and ``foreign_pre_chain`` of
+        `structlog.stdlib.ProcessorFormatter`.
+
+    .. versionadded:: 21.5.0
+    """
+
+    _handlers: Dict[
+        CallsiteParameter, Callable[[str, inspect.Traceback], Any]
+    ] = {
+        CallsiteParameter.PATHNAME: (
+            lambda module, frame_info: frame_info.filename
+        ),
+        CallsiteParameter.FILENAME: (
+            lambda module, frame_info: os.path.basename(frame_info.filename)
+        ),
+        CallsiteParameter.MODULE: (
+            lambda module, frame_info: os.path.splitext(
+                os.path.basename(frame_info.filename)
+            )[0]
+        ),
+        CallsiteParameter.FUNC_NAME: (
+            lambda module, frame_info: frame_info.function
+        ),
+        CallsiteParameter.LINENO: (
+            lambda module, frame_info: frame_info.lineno
+        ),
+        CallsiteParameter.THREAD: (
+            lambda module, frame_info: threading.get_ident()
+        ),
+        CallsiteParameter.THREAD_NAME: (
+            lambda module, frame_info: threading.current_thread().name
+        ),
+        CallsiteParameter.PROCESS: (lambda module, frame_info: os.getpid()),
+        CallsiteParameter.PROCESS_NAME: (
+            lambda module, frame_info: get_processname()
+        ),
+    }
+    _record_attribute_map: ClassVar[Dict[CallsiteParameter, str]] = {
+        CallsiteParameter.PATHNAME: "pathname",
+        CallsiteParameter.FILENAME: "filename",
+        CallsiteParameter.MODULE: "module",
+        CallsiteParameter.FUNC_NAME: "funcName",
+        CallsiteParameter.LINENO: "lineno",
+        CallsiteParameter.THREAD: "thread",
+        CallsiteParameter.THREAD_NAME: "threadName",
+        CallsiteParameter.PROCESS: "process",
+        CallsiteParameter.PROCESS_NAME: "processName",
+    }
+
+    class _RecordMapping(NamedTuple):
+        event_dict_key: str
+        record_attribute: str
+
+    __slots__ = [
+        "_parameters",
+        "_active_handlers",
+        "_additional_ignores",
+        "_record_mappings",
+    ]
+
+    def __init__(
+        self,
+        parameters: Collection[CallsiteParameter] = CALLSITE_PARAMETERS,
+        additional_ignores: Optional[List[str]] = None,
+    ) -> None:
+        if additional_ignores is None:
+            additional_ignores = []
+        # Ignore stack frames from the logging module. They will occur if this
+        # processor is used in ProcessorFormatter, and additionally the logging
+        # module should not be logging using structlog.
+        self._additional_ignores = ["logging", *additional_ignores]
+        self._active_handlers: List[
+            Tuple[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
+        ] = []
+        self._record_mappings: List[
+            "CallsiteParameterAdder._RecordMapping"
+        ] = []
+        for parameter in parameters:
+            self._active_handlers.append(
+                (parameter, self._handlers[parameter])
+            )
+            self._record_mappings.append(
+                self._RecordMapping(
+                    parameter.value,
+                    self._record_attribute_map[parameter],
+                )
+            )
+
+    def __call__(
+        self, logger: logging.Logger, name: str, event_dict: EventDict
+    ) -> EventDict:
+        sys.stderr.write(
+            f"CallsiteParameterAdder.__call__: event_dict = {event_dict}\n"
+        )
+        import traceback
+
+        traceback.print_stack()
+        record: Optional[logging.LogRecord] = event_dict.get("_record")
+        from_structlog: Optional[bool] = event_dict.get("_from_structlog")
+        # If the event dictionary has a record, but it comes from structlog,
+        # then the callsite parameters of the record will not be correct.
+        if record is not None and not from_structlog:
+            for mapping in self._record_mappings:
+                event_dict[mapping.event_dict_key] = record.__dict__[
+                    mapping.record_attribute
+                ]
+        else:
+            frame, module = _find_first_app_frame_and_name(
+                additional_ignores=self._additional_ignores
+            )
+            frame_info = inspect.getframeinfo(frame)
+            for parameter, handler in self._active_handlers:
+                handler(module, frame_info)
+                event_dict[parameter.value] = handler(module, frame_info)
         return event_dict

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -707,12 +707,6 @@ class CallsiteParameterAdder:
     def __call__(
         self, logger: logging.Logger, name: str, event_dict: EventDict
     ) -> EventDict:
-        sys.stderr.write(
-            f"CallsiteParameterAdder.__call__: event_dict = {event_dict}\n"
-        )
-        import traceback
-
-        traceback.print_stack()
         record: Optional[logging.LogRecord] = event_dict.get("_record")
         from_structlog: Optional[bool] = event_dict.get("_from_structlog")
         # If the event dictionary has a record, but it comes from structlog,

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -601,26 +601,27 @@ class CallsiteParameterAdder:
     not originate from `structlog` then the callsite information will be
     determined from the `logging.LogRecord` object. For event dictionaries
     without an embedded `logging.LogRecord` object the callsite will be
-    determined from stack trace, ignoring all intra-structlog calls and calls
-    from the `logging` module and frames that from module names starting with
-    values in ``additional_ignores``, if it is specified.
+    determined from the stack trace, ignoring all intra-structlog calls, calls
+    from the `logging` module, and stack frames from modules with names that
+    start with values in ``additional_ignores``, if it is specified.
 
-    The keys used for various callsite parameters in the event dictionary are
-    the string values of `CallsiteParameter` enum members.
+    The keys used for callsite parameters in the event dictionary are the
+    string values of `CallsiteParameter` enum members.
 
     :param parameters:
         A collection of `CallsiteParameter` values that should be added to the
         event dictionary.
 
     :param additional_ignores:
-        Additional names with which the a frame's module name must not start.
+        Additional names with which the a stack frame's module name must not
+        start for it to be considered when determening the callsite.
 
     .. note::
-        When used with `structlog.stdlib.ProcessorFormatter` the most
-        efficient configuration is to either use this processor in
-        ``foreign_pre_chain`` of `structlog.stdlib.ProcessorFormatter` and in
-        ``processors`` of `structlog.configure`, or to use it in ``processor``
-        of `structlog.stdlib.ProcessorFormatter` without using it in
+        When used with `structlog.stdlib.ProcessorFormatter` the most efficient
+        configuration is to either use this processor in ``foreign_pre_chain``
+        of `structlog.stdlib.ProcessorFormatter` and in ``processors`` of
+        `structlog.configure`, or to use it in ``processor`` of
+        `structlog.stdlib.ProcessorFormatter` without using it in
         ``processors`` of `structlog.configure` and ``foreign_pre_chain`` of
         `structlog.stdlib.ProcessorFormatter`.
 
@@ -675,7 +676,6 @@ class CallsiteParameterAdder:
         record_attribute: str
 
     __slots__ = [
-        "_parameters",
         "_active_handlers",
         "_additional_ignores",
         "_record_mappings",
@@ -733,6 +733,5 @@ class CallsiteParameterAdder:
             )
             frame_info = inspect.getframeinfo(frame)
             for parameter, handler in self._active_handlers:
-                handler(module, frame_info)
                 event_dict[parameter.value] = handler(module, frame_info)
         return event_dict

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -606,7 +606,7 @@ class CallsiteParameterAdder:
         event dictionary.
 
     :param additional_ignores:
-        Additional names with which the a stack frame's module name must not
+        Additional names with which a stack frame's module name must not
         start for it to be considered when determening the callsite.
 
     .. note::

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -55,7 +55,6 @@ __all__ = [
     "format_exc_info",
     "ExceptionPrettyPrinter",
     "StackInfoRenderer",
-    "CALLSITE_PARAMETERS",
     "CallsiteParameter",
     "CallsiteParameterAdder",
 ]
@@ -580,12 +579,6 @@ class CallsiteParameter(str, enum.Enum):
     PROCESS_NAME = "process_name"
 
 
-#: A set of all `CallsiteParameter` enum members.
-#:
-#: .. versionadded:: 21.5.0
-CALLSITE_PARAMETERS: Set[CallsiteParameter] = set(CallsiteParameter)
-
-
 class CallsiteParameterAdder:
     """
     Adds parameters of the callsite that an event dictionary originated from to
@@ -671,6 +664,8 @@ class CallsiteParameterAdder:
         CallsiteParameter.PROCESS_NAME: "processName",
     }
 
+    _all_parameters: Set[CallsiteParameter] = set(CallsiteParameter)
+
     class _RecordMapping(NamedTuple):
         event_dict_key: str
         record_attribute: str
@@ -683,7 +678,7 @@ class CallsiteParameterAdder:
 
     def __init__(
         self,
-        parameters: Collection[CallsiteParameter] = CALLSITE_PARAMETERS,
+        parameters: Collection[CallsiteParameter] = _all_parameters,
         additional_ignores: Optional[List[str]] = None,
     ) -> None:
         if additional_ignores is None:

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -753,6 +753,7 @@ class TestCallsiteParameterAdder:
         the dictionary returned by ``self.get_callsite_parameters`` contains
         keys for all callsite parameters.
         """
+
         assert self.parameter_strings == {
             member.value for member in self._all_parameters
         }
@@ -823,6 +824,7 @@ class TestCallsiteParameterAdder:
             "event": test_message,
             **callsite_params,
         }
+
         assert expected == actual
 
     @pytest.mark.parametrize(
@@ -885,6 +887,7 @@ class TestCallsiteParameterAdder:
             "event": test_message,
             **callsite_params,
         }
+
         assert expected == actual
 
     @pytest.mark.parametrize(
@@ -972,6 +975,7 @@ class TestCallsiteParameterAdder:
             "event": test_message,
             **callsite_params,
         }
+
         assert expected == actual
 
     @classmethod

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -4,9 +4,17 @@
 # repository for complete details.
 
 import datetime
+import inspect
+import itertools
 import json
+import logging
+import os
 import pickle
 import sys
+import threading
+
+from io import StringIO
+from typing import Any, Dict, List, Optional, Set
 
 import pytest
 
@@ -14,7 +22,12 @@ from freezegun import freeze_time
 
 import structlog
 
+from structlog import BoundLogger
+from structlog._utils import get_processname
 from structlog.processors import (
+    CALLSITE_PARAMETERS,
+    CallsiteParameter,
+    CallsiteParameterAdder,
     ExceptionPrettyPrinter,
     JSONRenderer,
     KeyValueRenderer,
@@ -27,7 +40,10 @@ from structlog.processors import (
     _json_fallback_handler,
     format_exc_info,
 )
+from structlog.stdlib import ProcessorFormatter
 from structlog.threadlocal import wrap_dict
+from structlog.types import EventDict
+from tests.utils import mock_getframe
 
 
 try:
@@ -714,3 +730,339 @@ class TestFigureOutExcInfo:
         e = ValueError()
 
         assert (e.__class__, e, None) == _figure_out_exc_info(e)
+
+
+class TestCallsiteParameterAdder:
+    parameter_strings = {
+        "pathname",
+        "filename",
+        "module",
+        "func_name",
+        "lineno",
+        "thread",
+        "thread_name",
+        "process",
+        "process_name",
+    }
+
+    def test_all_parameters(self) -> None:
+        """
+        All callsite parameters are included in ``self.parameter_strings`` and
+        the dictionary returned by ``self.get_callsite_parameters`` contains
+        keys for all callsite parameters.
+        """
+        assert self.parameter_strings == {
+            member.value for member in CALLSITE_PARAMETERS
+        }
+        assert self.parameter_strings == self.get_callsite_parameters().keys()
+
+    @pytest.mark.xfail(
+        reason=(
+            "CallsiteParameterAdder cannot "
+            "determine the callsite for async calls."
+        )
+    )
+    @pytest.mark.asyncio
+    async def test_async(self) -> None:
+        """
+        Callsite information for async invocations are correct.
+        """
+        try:
+            string_io = StringIO()
+
+            class StingIOLogger(structlog.PrintLogger):
+                def __init__(self):
+                    super().__init__(file=string_io)
+
+            processor = self.make_processor(None, ["concurrent", "threading"])
+            structlog.configure(
+                processors=[processor, JSONRenderer()],
+                logger_factory=StingIOLogger,
+                wrapper_class=structlog.stdlib.AsyncBoundLogger,
+                cache_logger_on_first_use=True,
+            )
+
+            logger = structlog.stdlib.get_logger()
+
+            callsite_params = self.get_callsite_parameters()
+            await logger.info("baz")
+
+            assert {"event": "baz", **callsite_params} == json.loads(
+                string_io.getvalue()
+            )
+
+        finally:
+            structlog.reset_defaults()
+
+    def test_additional_ignores(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        Stack frames from modules with names that start with values in
+        `additional_ignores` are ignored when determining the callsite.
+        """
+        test_message = "test message"
+        additional_ignores = ["tests.utils"]
+        processor = self.make_processor(None, additional_ignores)
+        event_dict: EventDict = {"event": test_message}
+
+        # WARNING: The below three lines are sensitive to relative line numbers
+        # (i.e. the invocation of processor must be two lines after the
+        # invocation of get_callsite_parameters) and is order sensitive (i.e.
+        # monkeypatch.setattr must occur after get_callsite_parameters but
+        # before invocation of processor).
+        callsite_params = self.get_callsite_parameters(2)
+        monkeypatch.setattr(sys, "_getframe", value=mock_getframe)
+        actual = processor(None, None, event_dict)
+
+        expected = {
+            "event": test_message,
+            **callsite_params,
+        }
+        assert expected == actual
+
+    @pytest.mark.parametrize(
+        "origin, parameter_strings",
+        itertools.product(
+            ["logging", "structlog"],
+            [
+                None,
+                *[{parameter} for parameter in parameter_strings],
+                set(),
+                parameter_strings,
+                {"pathname", "filename"},
+                {"module", "func_name"},
+            ],
+        ),
+    )
+    def test_processor(
+        self,
+        origin: str,
+        parameter_strings: Optional[Set[str]],
+    ):
+        """
+        The correct callsite parameters are added to event dictionaries.
+        """
+        test_message = "test message"
+        processor = self.make_processor(parameter_strings)
+        if origin == "structlog":
+            event_dict: EventDict = {"event": test_message}
+            callsite_params = self.get_callsite_parameters()
+            actual = processor(None, None, event_dict)
+        elif origin == "logging":
+            callsite_params = self.get_callsite_parameters()
+            record = logging.LogRecord(
+                "name",
+                logging.INFO,
+                callsite_params["pathname"],
+                callsite_params["lineno"],
+                test_message,
+                None,
+                None,
+                callsite_params["func_name"],
+            )
+            event_dict: EventDict = {
+                "event": test_message,
+                "_record": record,
+                "_from_structlog": False,
+            }
+            actual = processor(None, None, event_dict)
+        else:
+            raise ValueError(f"invalid origin {origin}")
+        actual = {
+            key: value
+            for key, value in actual.items()
+            if not key.startswith("_")
+        }
+        callsite_params = self.filter_parameter_dict(
+            callsite_params, parameter_strings
+        )
+        expected = {
+            "event": test_message,
+            **callsite_params,
+        }
+        assert expected == actual
+
+    @pytest.mark.parametrize(
+        "setup, origin, parameter_strings",
+        itertools.product(
+            ["common-without-pre", "common-with-pre", "shared", "everywhere"],
+            ["logging", "structlog"],
+            [
+                None,
+                *[{parameter} for parameter in parameter_strings],
+                set(),
+                parameter_strings,
+                {"pathname", "filename"},
+                {"module", "func_name"},
+            ],
+        ),
+    )
+    def test_e2e(
+        self,
+        setup: str,
+        origin: str,
+        parameter_strings: Optional[Set[str]],
+    ) -> None:
+        """
+        Logging output contains the correct callsite parameters.
+        """
+        logger = logging.Logger(sys._getframe().f_code.co_name)
+        string_io = StringIO()
+        handler = logging.StreamHandler(string_io)
+        processors = [self.make_processor(parameter_strings)]
+        if setup == "common-without-pre":
+            common_processors = processors
+            formatter = ProcessorFormatter(
+                processors=[*processors, JSONRenderer()]
+            )
+        elif setup == "common-with-pre":
+            common_processors = processors
+            formatter = ProcessorFormatter(
+                foreign_pre_chain=processors,
+                processors=[JSONRenderer()],
+            )
+        elif setup == "shared":
+            common_processors = []
+            formatter = ProcessorFormatter(
+                processors=[*processors, JSONRenderer()],
+            )
+        elif setup == "everywhere":
+            common_processors = processors
+            formatter = ProcessorFormatter(
+                foreign_pre_chain=processors,
+                processors=[*processors, JSONRenderer()],
+            )
+        else:
+            raise ValueError(f"invalid setup {setup}")
+        handler.setFormatter(formatter)
+        handler.setLevel(0)
+        logger.addHandler(handler)
+        logger.setLevel(0)
+
+        test_message = "test message"
+        if origin == "logging":
+            callsite_params = self.get_callsite_parameters()
+            logger.info(test_message)
+        elif origin == "structlog":
+            ctx: Dict[str, Any] = {}
+            bound_logger = BoundLogger(
+                logger,
+                [*common_processors, ProcessorFormatter.wrap_for_formatter],
+                ctx,
+            )
+            callsite_params = self.get_callsite_parameters()
+            bound_logger.info(test_message)
+        else:
+            raise ValueError(f"invalid front {origin}")
+
+        callsite_params = self.filter_parameter_dict(
+            callsite_params, parameter_strings
+        )
+        actual = {
+            key: value
+            for key, value in json.loads(string_io.getvalue()).items()
+            if not key.startswith("_")
+        }
+        expected = {
+            "event": test_message,
+            **callsite_params,
+        }
+        assert expected == actual
+
+    @classmethod
+    def make_processor(
+        cls,
+        parameter_strings: Optional[Set[str]],
+        additional_ignores: Optional[List[str]] = None,
+    ) -> CallsiteParameterAdder:
+        """
+        Creates a ``CallsiteParameterAdder`` with parameters matching the
+        supplied ``parameter_strings`` value and with the supplied
+        ``additional_ignores`` values.
+
+        :param parameter_strings:
+            Strings for which corresponding ``CallsiteParameters`` should be
+            included in the resulting ``CallsiteParameterAdded``.
+        :param additional_ignores:
+            Used as ``additional_ignores`` for the resulting
+            ``CallsiteParameterAdded``.
+        """
+        if parameter_strings is None:
+            return CallsiteParameterAdder(
+                additional_ignores=additional_ignores
+            )
+        else:
+            parameters = cls.filter_parameters(parameter_strings)
+            return CallsiteParameterAdder(
+                parameters=parameters,
+                additional_ignores=additional_ignores,
+            )
+
+    @classmethod
+    def filter_parameters(
+        cls, parameter_strings: Optional[Set[str]]
+    ) -> Set[CallsiteParameter]:
+        """
+        Returns a set containing the elements of
+        `structlog.processor.CALLSITE_PARAMETERS` with values that are in
+        ``parameter_strings``, if ``parameter_strings`` is ``None`` then
+        ``structlog.processor.CALLSITE_PARAMETERS` will be returned.
+
+        :param parameter_strings:
+            The parameters strings for which corresponding
+            `structlog.processor.CALLSITE_PARAMETERS` values should be
+            returned. If this value is `None` then all
+            `structlog.processor.CALLSITE_PARAMETERS` values will be returned.
+        """
+        if parameter_strings is None:
+            return CALLSITE_PARAMETERS
+        return {
+            parameter
+            for parameter in CALLSITE_PARAMETERS
+            if parameter.value in parameter_strings
+        }
+
+    @classmethod
+    def filter_parameter_dict(
+        cls, input: Dict[str, Any], parameter_strings: Optional[Set[str]]
+    ) -> Dict[str, Any]:
+        """
+        Returns a dictionary that is equivalent to ``input`` but with all keys
+        not in ``parameter_strings`` removed.
+
+        :param parameter_strings:
+            The keys to keep in the dictionary, if this value is ``None`` then
+            all keys matching ``cls.parameter_strings`` are kept.
+        """
+        if parameter_strings is None:
+            parameter_strings = cls.parameter_strings
+        return {
+            key: value
+            for key, value in input.items()
+            if key in parameter_strings
+        }
+
+    @classmethod
+    def get_callsite_parameters(cls, offset: int = 1) -> Dict[str, Any]:
+        """
+        This function creates dictionary of callsite parameters for the line
+        that is ``offset`` lines after the invocation of this function.
+
+        :param offset:
+            The amount of lines after the invocation of this function that
+            callsite parameters should be generated for.
+        """
+        frame_info = inspect.stack()[1]
+        frame_traceback = inspect.getframeinfo(frame_info[0])
+        return {
+            "pathname": frame_traceback.filename,
+            "filename": os.path.basename(frame_traceback.filename),
+            "module": os.path.splitext(
+                os.path.basename(frame_traceback.filename)
+            )[0],
+            "func_name": frame_info.function,
+            "lineno": frame_info.lineno + offset,
+            "thread": threading.get_ident(),
+            "thread_name": threading.current_thread().name,
+            "process": os.getpid(),
+            "process_name": get_processname(),
+        }

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -952,7 +952,7 @@ class TestCallsiteParameterAdder:
             callsite_params = self.get_callsite_parameters()
             bound_logger.info(test_message)
         else:
-            raise ValueError(f"invalid front {origin}")
+            raise ValueError(f"invalid origin {origin}")
 
         callsite_params = self.filter_parameter_dict(
             callsite_params, parameter_strings
@@ -976,7 +976,7 @@ class TestCallsiteParameterAdder:
     ) -> CallsiteParameterAdder:
         """
         Creates a ``CallsiteParameterAdder`` with parameters matching the
-        supplied ``parameter_strings`` value and with the supplied
+        supplied ``parameter_strings`` values and with the supplied
         ``additional_ignores`` values.
 
         :param parameter_strings:

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -25,7 +25,6 @@ import structlog
 from structlog import BoundLogger
 from structlog._utils import get_processname
 from structlog.processors import (
-    CALLSITE_PARAMETERS,
     CallsiteParameter,
     CallsiteParameterAdder,
     ExceptionPrettyPrinter,
@@ -745,6 +744,8 @@ class TestCallsiteParameterAdder:
         "process_name",
     }
 
+    _all_parameters = set(CallsiteParameter)
+
     def test_all_parameters(self) -> None:
         """
         All callsite parameters are included in ``self.parameter_strings`` and
@@ -752,7 +753,7 @@ class TestCallsiteParameterAdder:
         keys for all callsite parameters.
         """
         assert self.parameter_strings == {
-            member.value for member in CALLSITE_PARAMETERS
+            member.value for member in self._all_parameters
         }
         assert self.parameter_strings == self.get_callsite_parameters().keys()
 
@@ -1002,22 +1003,20 @@ class TestCallsiteParameterAdder:
         cls, parameter_strings: Optional[Set[str]]
     ) -> Set[CallsiteParameter]:
         """
-        Returns a set containing the elements of
-        `structlog.processor.CALLSITE_PARAMETERS` with values that are in
-        ``parameter_strings``, if ``parameter_strings`` is ``None`` then
-        ``structlog.processor.CALLSITE_PARAMETERS` will be returned.
+        Returns a set containing all ``CallsiteParameter`` members with values
+        that are in ``parameter_strings``.
 
         :param parameter_strings:
             The parameters strings for which corresponding
-            `structlog.processor.CALLSITE_PARAMETERS` values should be
+            ``CallsiteParameter`` members should be
             returned. If this value is `None` then all
-            `structlog.processor.CALLSITE_PARAMETERS` values will be returned.
+            ``CallsiteParameter`` will be returned.
         """
         if parameter_strings is None:
-            return CALLSITE_PARAMETERS
+            return cls._all_parameters
         return {
             parameter
-            for parameter in CALLSITE_PARAMETERS
+            for parameter in cls._all_parameters
             if parameter.value in parameter_strings
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,6 +58,7 @@ class TestGetProcessname:
             name="name",
             value=tmp_name,
         )
+
         assert get_processname() == tmp_name
 
     def test_no_multiprocessing(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -76,6 +77,7 @@ class TestGetProcessname:
             name="modules",
             value={},
         )
+
         assert get_processname() == "n/a"
 
     def test_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -93,4 +95,5 @@ class TestGetProcessname:
             name="current_process",
             value=_current_process,
         )
+
         assert get_processname() == "n/a"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,7 @@ class TestGetProcessname:
             name="modules",
             value={},
         )
-        assert get_processname() == "MainProcess"
+        assert get_processname() == "n/a"
 
     def test_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """
@@ -93,4 +93,4 @@ class TestGetProcessname:
             name="current_process",
             value=_current_process,
         )
-        assert get_processname() == "MainProcess"
+        assert get_processname() == "n/a"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,12 +4,14 @@
 # repository for complete details.
 
 import errno
+import multiprocessing
+import sys
 
 import pytest
 
 from pretend import raiser
 
-from structlog._utils import until_not_interrupted
+from structlog._utils import get_processname, until_not_interrupted
 
 
 class TestUntilNotInterrupted:
@@ -35,3 +37,60 @@ class TestUntilNotInterrupted:
         until_not_interrupted(raise_on_first_three)
 
         assert 3 == calls[0]
+
+
+class TestGetProcessname:
+    def test_default(self):
+        """
+        The returned process name matches the name of the current process from
+        the `multiprocessing` module.
+        """
+        assert get_processname() == multiprocessing.current_process().name
+
+    def test_changed(self, monkeypatch: pytest.MonkeyPatch):
+        """
+        The returned process name matches the name of the current process from
+        the `multiprocessing` module if it is not the default.
+        """
+        tmp_name = "fakename"
+        monkeypatch.setattr(
+            target=multiprocessing.current_process(),
+            name="name",
+            value=tmp_name,
+        )
+        assert get_processname() == tmp_name
+
+    def test_no_multiprocessing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        The returned process name is the default process name if the
+        `multiprocessing` module is not available.
+        """
+        tmp_name = "fakename"
+        monkeypatch.setattr(
+            target=multiprocessing.current_process(),
+            name="name",
+            value=tmp_name,
+        )
+        monkeypatch.setattr(
+            target=sys,
+            name="modules",
+            value={},
+        )
+        assert get_processname() == "MainProcess"
+
+    def test_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        The returned process name is the default process name when an exception
+        is thrown when an attempt is made to retrieve the current process name
+        from the `multiprocessing` module.
+        """
+
+        def _current_process() -> None:
+            raise RuntimeError("test")
+
+        monkeypatch.setattr(
+            target=multiprocessing,
+            name="current_process",
+            value=_current_process,
+        )
+        assert get_processname() == "MainProcess"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,8 +6,24 @@
 """
 Shared test utilities.
 """
+import sys
+
+from types import FrameType
 
 from structlog._log_levels import _NAME_TO_LEVEL
 
 
 stdlib_log_methods = [m for m in _NAME_TO_LEVEL if m != "notset"]
+
+
+_REAL_GETFRAME = sys._getframe
+
+
+def mock_getframe(__depth: int = 0) -> FrameType:
+    """
+    This function is used to inject an additional stack frame from a moudle
+    that can be used to test  the ``additional_ignores`` parameter of the
+    `structlog._frames._find_first_app_frame_and_name` parameter.
+    """
+    real_frame: FrameType = _REAL_GETFRAME(__depth)
+    return real_frame

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,8 +22,8 @@ _REAL_GETFRAME = sys._getframe
 def mock_getframe(__depth: int = 0) -> FrameType:
     """
     This function is used to inject an additional stack frame from a moudle
-    that can be used to test  the ``additional_ignores`` parameter of the
-    `structlog._frames._find_first_app_frame_and_name` parameter.
+    that can be used to test  the ``additional_ignores`` parameter of
+    `structlog._frames._find_first_app_frame_and_name`.
     """
     real_frame: FrameType = _REAL_GETFRAME(__depth)
     return real_frame

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ _REAL_GETFRAME = sys._getframe
 
 def mock_getframe(__depth: int = 0) -> FrameType:
     """
-    This function is used to inject an additional stack frame from a moudle
+    This function is used to inject an additional stack frame from a module
     that can be used to test  the ``additional_ignores`` parameter of
     `structlog._frames._find_first_app_frame_and_name`.
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,24 +6,8 @@
 """
 Shared test utilities.
 """
-import sys
-
-from types import FrameType
 
 from structlog._log_levels import _NAME_TO_LEVEL
 
 
 stdlib_log_methods = [m for m in _NAME_TO_LEVEL if m != "notset"]
-
-
-_REAL_GETFRAME = sys._getframe
-
-
-def mock_getframe(__depth: int = 0) -> FrameType:
-    """
-    This function is used to inject an additional stack frame from a module
-    that can be used to test  the ``additional_ignores`` parameter of
-    `structlog._frames._find_first_app_frame_and_name`.
-    """
-    real_frame: FrameType = _REAL_GETFRAME(__depth)
-    return real_frame

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -14,6 +14,8 @@ from typing import Any, Callable, List, Optional
 
 import structlog
 
+from structlog.processors import CALLSITE_PARAMETERS, CallsiteParameter
+
 
 bl = structlog.get_logger()
 bl.msg("hello", whom="world", x=42, y={})
@@ -65,6 +67,42 @@ structlog.configure(
 
 formatter = structlog.stdlib.ProcessorFormatter(
     processor=structlog.dev.ConsoleRenderer(),
+)
+
+formatter = structlog.stdlib.ProcessorFormatter(
+    processors=[
+        structlog.processors.CallsiteParameterAdder(),
+        structlog.processors.CallsiteParameterAdder(
+            CALLSITE_PARAMETERS, ["threading"]
+        ),
+        structlog.processors.CallsiteParameterAdder(
+            CALLSITE_PARAMETERS, additional_ignores=["threading"]
+        ),
+        structlog.processors.CallsiteParameterAdder(
+            parameters=CALLSITE_PARAMETERS, additional_ignores=["threading"]
+        ),
+        structlog.processors.CallsiteParameterAdder(
+            [
+                CallsiteParameter.FILENAME,
+                CallsiteParameter.FUNC_NAME,
+                CallsiteParameter.LINENO,
+            ]
+        ),
+        structlog.processors.CallsiteParameterAdder(
+            parameters=[
+                CallsiteParameter.FILENAME,
+                CallsiteParameter.FUNC_NAME,
+                CallsiteParameter.LINENO,
+            ]
+        ),
+        structlog.processors.CallsiteParameterAdder(
+            parameters=[
+                CallsiteParameter.FILENAME,
+                CallsiteParameter.FUNC_NAME,
+                CallsiteParameter.LINENO,
+            ]
+        ),
+    ],
 )
 
 handler = logging.StreamHandler()

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, List, Optional
 
 import structlog
 
-from structlog.processors import CALLSITE_PARAMETERS, CallsiteParameter
+from structlog.processors import CallsiteParameter
 
 
 bl = structlog.get_logger()
@@ -73,13 +73,13 @@ formatter = structlog.stdlib.ProcessorFormatter(
     processors=[
         structlog.processors.CallsiteParameterAdder(),
         structlog.processors.CallsiteParameterAdder(
-            CALLSITE_PARAMETERS, ["threading"]
+            set(CallsiteParameter), ["threading"]
         ),
         structlog.processors.CallsiteParameterAdder(
-            CALLSITE_PARAMETERS, additional_ignores=["threading"]
+            set(CallsiteParameter), additional_ignores=["threading"]
         ),
         structlog.processors.CallsiteParameterAdder(
-            parameters=CALLSITE_PARAMETERS, additional_ignores=["threading"]
+            parameters=set(CallsiteParameter), additional_ignores=["threading"]
         ),
         structlog.processors.CallsiteParameterAdder(
             [


### PR DESCRIPTION
# Summary

This PR creates a `CallsiteParameterAdder` processor which will populate the event dictionary with callsite parameters.

The following callsite parameters are supported:

```
FILENAME = 'filename'
The basename part of the full path to the python source file of the callsite.

FUNC_NAME = 'func_name'
The name of the function that the callsite was in.

LINENO = 'lineno'
The line number of the callsite.

MODULE = 'module'
The python module the callsite was in. This mimicks the module attribute of logging.LogRecord objects and will be the basename, without extension, of the full path to the python source file of the callsite.

PATHNAME = 'pathname'
The full path to the python source file of the callsite.

PROCESS = 'process'
The ID of the process the callsite was executed in.

PROCESS_NAME = 'process_name'
The name of the process the callsite was executed in.

THREAD = 'thread'
The ID of the thread the callsite was executed in.

THREAD_NAME = 'thread_name'
The name of the thread the callsite was executed in.
```

Fixes #378

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
