### PR TITLE
Narrow the return type of bind,unbind,try_unbind,new in subclass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Whenever there is a need to break compatibility, it is announced here in the cha
 
 .. changelog
 
-XX.Y.Z (UNRELEASED)
+22.1.0 (UNRELEASED)
 -------------------
 
 Backward-incompatible changes:
@@ -36,7 +36,9 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Overloaded the ``bind``, ``unbind``, ``try_unbind`` and ``new`` methods in the ``FilteringBoundLogger`` `Protocol <https://docs.python.org/3/library/typing.html#typing.Protocol>_`.
+  This makes it easier to use objects of type ``FilteringBoundLogger`` in a typed context.
+  `#392 <https://github.com/hynek/structlog/pull/392>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-- Overloaded the ``bind``, ``unbind``, ``try_unbind`` and ``new`` methods in the ``FilteringBoundLogger`` `Protocol <https://docs.python.org/3/library/typing.html#typing.Protocol>_`.
+- Overloaded the ``bind``, ``unbind``, ``try_unbind`` and ``new`` methods in the ``FilteringBoundLogger`` `Protocol <https://docs.python.org/3/library/typing.html#typing.Protocol>`_.
   This makes it easier to use objects of type ``FilteringBoundLogger`` in a typed context.
   `#392 <https://github.com/hynek/structlog/pull/392>`_
 

--- a/src/structlog/types.py
+++ b/src/structlog/types.py
@@ -130,6 +130,34 @@ class FilteringBoundLogger(BindableLogger, Protocol):
     .. versionadded:: 20.2.0
     """
 
+    def bind(self, **new_values: Any) -> "FilteringBoundLogger":
+        """
+        Return a new logger with *new_values* added to the existing ones.
+
+        .. versionadded:: 22.1.0
+        """
+
+    def unbind(self, *keys: str) -> "FilteringBoundLogger":
+        """
+        Return a new logger with *keys* removed from the context.
+
+        .. versionadded:: 22.1.0
+        """
+
+    def try_unbind(self, *keys: str) -> "FilteringBoundLogger":
+        """
+        Like :meth:`unbind`, but best effort: missing keys are ignored.
+
+        .. versionadded:: 22.1.0
+        """
+
+    def new(self, **new_values: Any) -> "FilteringBoundLogger":
+        """
+        Clear context and binds *initial_values* using `bind`.
+
+        .. versionadded:: 22.1.0
+        """
+
     def debug(self, event: str, **kw: Any) -> Any:
         """
         Log *event* with **kw** at **debug** level.

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, List, Optional
 import structlog
 
 from structlog.processors import CallsiteParameter
+from structlog.types import FilteringBoundLogger
 
 
 bl = structlog.get_logger()
@@ -279,3 +280,15 @@ structlog.configure(
 
 with structlog.threadlocal.bound_threadlocal(x=42):
     pass
+
+
+def typecheck_filtering_return() -> None:
+    fblogger: FilteringBoundLogger = structlog.get_logger(__name__)
+    fblog = fblogger.bind(key1="value1", key2="value2", key3="value3")
+    fblog.info("values bound")
+    fblog = fblog.unbind("key1")
+    fblog.debug("value unbound")
+    fblog = fblog.try_unbind("bad_key")
+    fblog.warn("no value unbound because key not defined")
+    fblog = fblog.new(new="value")
+    fblog.info("this is a whole new logger")


### PR DESCRIPTION
# Summary

This narrows the return type of `bind`,`unbind`,`try_unbind` and `new`
in `FilteringBoundLogger` to return `FilteringBoundLogger` instead of
`BindableLogger`. This makes it easier to use structlog in a typed
context like this:

```python
def typecheck_filtering_return() -> None:
    fblogger: FilteringBoundLogger = structlog.get_logger(__name__)
    fblog = fblogger.bind(key1="value1", key2="value2", key3="value3")
    fblog.info("values bound")
    fblog = fblog.unbind("key1")
    fblog.debug("value unbound")
    fblog = fblog.try_unbind("bad_key")
    fblog.warn("no value unbound because key not defined")
    fblog = fblog.new(new="value")
    fblog.info("this is a whole new logger")
```

Without this change the above example will result in a type
error when using `mypy --strict` as the type of `fblog` will be `BindableLogger`
which does not have an `info` method:

```console
typing_examples.py:288: error: "BindableLogger" has no attribute "info"
typing_examples.py:290: error: "BindableLogger" has no attribute "debug"
typing_examples.py:292: error: "BindableLogger" has no attribute "warn"
typing_examples.py:294: error: "BindableLogger" has no attribute "info"
Found 4 errors in 1 file (checked 19 source files)
```

Fixes #390


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
