### PR TITLE
fix: Use a noop with the same signature as the real one for make_filtering_bound_logger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,9 @@ Backward-incompatible changes:
 
 - Python 3.6 is not supported anymore.
 - Pickling is now only possible with protocol version 3 and newer.
+- ``structlog.make_filtering_bound_logger()`` now returns a method with the same signature for all log levels, whether they are active or not.
+  This ensures that invalid calls to inactive log levels are caught immediately and don't explode once the log level changes.
+  `#401 <https://github.com/hynek/structlog/pull/401>`_
 
 
 Deprecations:

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -67,7 +67,7 @@ def add_log_level(
     return event_dict
 
 
-def _nop(*args: Any, **kw: Any) -> Any:
+def _nop(self: Any, event: str, **kw: Any) -> Any:
     return None
 
 

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -34,11 +34,33 @@ class TestFilteringLogger:
 
     def test_one_below(self, bl, cl):
         """
-        if log level is exactly the min_level, log.
+        if log level is below the min_level, don't log.
         """
         bl.debug("nope")
 
         assert [] == cl.calls
+
+    def test_filter_bound_below_missing_event_string(self, bl, cl):
+        """
+        Missing event arg causes exception below min_level.
+        """
+        with pytest.raises(TypeError) as exc_info:
+            bl.debug(missing="event string!")
+        assert exc_info.type is TypeError
+
+        message = "missing 1 required positional argument: 'event'"
+        assert message in exc_info.value.args[0]
+
+    def test_filter_bound_exact_missing_event_string(self, bl, cl):
+        """
+        Missing event arg causes exception even at min_level.
+        """
+        with pytest.raises(TypeError) as exc_info:
+            bl.info(missing="event string!")
+        assert exc_info.type is TypeError
+
+        message = "missing 1 required positional argument: 'event'"
+        assert message in exc_info.value.args[0]
 
     def test_exception(self, bl, cl):
         """


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
In my team's app, we're using `make_filtering_bound_logger` in our configuration, which is working fine except in one corner case. Another developer introduced a bug that was missed in review and testing, and it only appears at runtime when the log level is DEBUG (below INFO, our standard level):

```py
log.debug(x=y)
```

Obviously this is incorrect: there needs to be an `event` string in this call. However, the original `_nop` method that gets returned has no checks for this missing argument, so their (admittedly poor) testing didn't turn up a problem at this line. Later when running at DEBUG level to research a different issue, the entire app failed to start up because of this call alone.

Root cause for us was incorrect code from our teammate, but I figured it could use some help from structlog, which seems to be silently passing what should be an error.

This change operates identically, returning `None` when the log level is too high. Now, though, it returns a method with the same signature every time, so a logging call written incorrectly will always raise an exception for missing arguments, regardless of the configured log level.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.rst).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
