### PR TITLE
Handle monkey-patched stdout

### DIFF
--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -40,7 +40,10 @@ _BUILTIN_DEFAULT_PROCESSORS: Sequence[Processor] = [
     set_exc_info,
     TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
     ConsoleRenderer(
-        colors=_use_colors and sys.stdout is not None and hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+        colors=_use_colors
+        and sys.stdout is not None
+        and hasattr(sys.stdout, "isatty")
+        and sys.stdout.isatty()
     ),
 ]
 _BUILTIN_DEFAULT_CONTEXT_CLASS = cast(Type[Context], dict)

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -40,7 +40,7 @@ _BUILTIN_DEFAULT_PROCESSORS: Sequence[Processor] = [
     set_exc_info,
     TimeStamper(fmt="%Y-%m-%d %H:%M.%S", utc=False),
     ConsoleRenderer(
-        colors=_use_colors and sys.stdout is not None and sys.stdout.isatty()
+        colors=_use_colors and sys.stdout is not None and hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
     ),
 ]
 _BUILTIN_DEFAULT_CONTEXT_CLASS = cast(Type[Context], dict)


### PR DESCRIPTION
# Summary

In some Python environments (e.g. Maya 2022's mayapy.exe), sys.stdout has been monkey-patched to something other than the expected stdout. As such, it doesn't actually have an `isatty` method and raises an AttributeError in response.