### PR TITLE
Add capture_configured_logger_calls for unit testing

### DIFF
--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -183,3 +183,22 @@ class CapturingLoggerFactory:
 
     def __call__(self, *args: Any) -> CapturingLogger:
         return self.logger
+
+
+@contextmanager
+def capture_configured_logger_calls() -> Generator[List[CapturedCall], None, None]:
+    """
+    Context manager that tracks calls to the logger while it is active.
+    All configuration remains active, except for the ``logger_factory``,
+    which is replaced by ``CapturingLoggerFactory``.
+    """
+    config = get_config()
+    factory = CapturingLoggerFactory()
+    original_factory = config['logger_factory']
+    config['logger_factory'] = factory
+    try:
+        configure(**config)
+        yield factory.logger.calls
+    finally:
+        config['logger_factory'] = original_factory
+        configure(**config)

--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -186,7 +186,9 @@ class CapturingLoggerFactory:
 
 
 @contextmanager
-def capture_configured_logger_calls() -> Generator[List[CapturedCall], None, None]:
+def capture_configured_logger_calls() -> Generator[
+    List[CapturedCall], None, None
+]:
     """
     Context manager that tracks calls to the logger while it is active.
     All configuration remains active, except for the ``logger_factory``,
@@ -194,11 +196,11 @@ def capture_configured_logger_calls() -> Generator[List[CapturedCall], None, Non
     """
     config = get_config()
     factory = CapturingLoggerFactory()
-    original_factory = config['logger_factory']
-    config['logger_factory'] = factory
+    original_factory = config["logger_factory"]
+    config["logger_factory"] = factory
     try:
         configure(**config)
         yield factory.logger.calls
     finally:
-        config['logger_factory'] = original_factory
+        config["logger_factory"] = original_factory
         configure(**config)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -4,9 +4,16 @@
 # repository for complete details.
 
 import pytest
+
 from freezegun import freeze_time
 
-from structlog import configure, get_config, get_logger, reset_defaults, testing
+from structlog import (
+    configure,
+    get_config,
+    get_logger,
+    reset_defaults,
+    testing,
+)
 from structlog.processors import TimeStamper
 from structlog.stdlib import LoggerFactory
 from structlog.testing import (
@@ -179,12 +186,20 @@ class TestCaptureConfiguredLoggerCalls:
             CapturedCall(
                 method_name="info",
                 args=(),
-                kwargs={"x": "y", "event": "hello", "timestamp": "1977-12-28T16:00:00Z"}
+                kwargs={
+                    "x": "y",
+                    "event": "hello",
+                    "timestamp": "1977-12-28T16:00:00Z",
+                },
             ),
             CapturedCall(
                 method_name="info",
                 args=(),
-                kwargs={"a": "b", "event": "goodbye", "timestamp": "1977-12-28T16:00:00Z"}
+                kwargs={
+                    "a": "b",
+                    "event": "goodbye",
+                    "timestamp": "1977-12-28T16:00:00Z",
+                },
             ),
         ] == calls
 
@@ -193,9 +208,7 @@ class TestCaptureConfiguredLoggerCalls:
         The formatter is patched within the contextmanager and restored on exit.
         """
         original_factory = LoggerFactory()
-        configure(
-            logger_factory=original_factory
-        )
+        configure(logger_factory=original_factory)
 
         with testing.capture_configured_logger_calls():
             assert original_factory is not self.get_active_factory()
@@ -207,9 +220,7 @@ class TestCaptureConfiguredLoggerCalls:
         The formatter is patched in the contextmanager and restored on errors.
         """
         original_factory = LoggerFactory()
-        configure(
-            logger_factory=original_factory
-        )
+        configure(logger_factory=original_factory)
 
         with pytest.raises(NotImplementedError):
             with testing.capture_configured_logger_calls():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -205,7 +205,8 @@ class TestCaptureConfiguredLoggerCalls:
 
     def test_restores_formatter_on_success(self):
         """
-        The formatter is patched within the contextmanager and restored on exit.
+        The formatter is patched within the contextmanager
+        and restored on exit.
         """
         original_factory = LoggerFactory()
         configure(logger_factory=original_factory)
@@ -217,7 +218,8 @@ class TestCaptureConfiguredLoggerCalls:
 
     def test_restores_processors_on_error(self):
         """
-        The formatter is patched in the contextmanager and restored on errors.
+        The formatter is patched in the contextmanager
+        and restored on errors.
         """
         original_factory = LoggerFactory()
         configure(logger_factory=original_factory)


### PR DESCRIPTION
# Summary

Adds a new context manager for testing named `structlog.testing.capture_configured_logger_calls`. 

The purpose is to allow inspection of logger calls within tests, but to keep all existing processors intact so that that their behavior may also be validated.

# Pull Request Check List

- [X] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.


If this looks acceptable I can update documentation/changelog
