### PR TITLE
Apply capture_logs to initialized bound loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ So please make sure to **always** properly configure your applications.
   [#401](https://github.com/hynek/structlog/pull/401)
 - `structlog.PrintLogger` -- that is used by default -- now uses `print()` for printing, making it a better citizen for interactive terminal applications.
   [#399](https://github.com/hynek/structlog/pull/399)
+- `structlog.testing.capture_logs` now works for already initialized bound loggers.
+  [#408](https://github.com/hynek/structlog/pull/412)
 
 
 ### Fixed


### PR DESCRIPTION
# Summary

This changes the `structlog.testing.capture_logs` contextmanager to also work for already initialized bound loggers.

Fixes #408.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
