### PR TITLE
Fix configuration example for stdlib

### DIFF
--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -168,9 +168,11 @@ A basic configuration to output structured logs in JSON format looks like this:
             structlog.processors.UnicodeDecoder(),
             # Add callsite parameters.
             structlog.processors.CallsiteParameterAdder(
-                CallsiteParameter.FILENAME,
-                CallsiteParameter.FUNC_NAME,
-                CallsiteParameter.LINENO,
+                (
+                    structlog.processors.CallsiteParameter.FILENAME,
+                    structlog.processors.CallsiteParameter.FUNC_NAME,
+                    structlog.processors.CallsiteParameter.LINENO,
+                )
             ),
             # Render the final event dict as JSON.
             structlog.processors.JSONRenderer()

--- a/docs/standard-library.rst
+++ b/docs/standard-library.rst
@@ -168,11 +168,11 @@ A basic configuration to output structured logs in JSON format looks like this:
             structlog.processors.UnicodeDecoder(),
             # Add callsite parameters.
             structlog.processors.CallsiteParameterAdder(
-                (
+                {
                     structlog.processors.CallsiteParameter.FILENAME,
                     structlog.processors.CallsiteParameter.FUNC_NAME,
                     structlog.processors.CallsiteParameter.LINENO,
-                )
+                }
             ),
             # Render the final event dict as JSON.
             structlog.processors.JSONRenderer()


### PR DESCRIPTION
# Summary

Fixes configuration sample in "Standard Library Logging" documentation page. At least as of 21.5.0 copy-pasting it required changes for it to work,


# Pull Request Check List

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.