### PR TITLE
recipe for passing context to worker threads

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -146,3 +146,42 @@ You can observe the following:
 These two methods and one attribute are all you need to write own *bound loggers*.
 
 [dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
+
+
+(passing-context)=
+## Passing Context to Worker Threads
+
+When using Threads to process work in parallel, there is a need to pass global information, such as `request_id` to the worker threads.  Outside of the Thread world, it is easy enough to use `bind_contextvars()` for this purpose, but how to do the same for Threads?  One way is to retrieve the context vars and pass them along to the worker threads.  Inside of the worker, re-bind them using `bind_contextvars`.  A small example may help here. This example uses `pathos` to create a ThreadPoool.  The context vars are retrieved and passed as the first argument to the partial function.  The pool invokes the partial function, once for each element of `workers`.  Inside of `do_some_work`, the context vars are bound and a message about the great work being performed is logged.
+
+
+```
+from functools import partial
+
+import structlog
+from pathos.threading import ThreadPool
+from structlog.contextvars import bind_contextvars
+
+
+def do_some_work(ctx: dict, this_worker: str):
+    logger = structlog.get_logger(__name__)
+    bind_contextvars(**ctx)
+    logger.info("WorkerDidSomeWork", worker=this_worker)
+
+
+def structlog_with_threadpool(f):
+    ctx = structlog.contextvars.get_contextvars()
+    func = partial(f, ctx)
+    workers = "12345"
+    with ThreadPool() as pool:
+        return list(pool.map(func, workers))
+
+
+def manager(request_id: str):
+    bind_contextvars(request_id="my-request-id")
+    logger = structlog.get_logger(__name__)
+    logger.info("StartingWorkers")
+    structlog_with_threadpool(do_some_work)
+
+```
+
+See [Example of passing context variables to worker threads](https://github.com/hynek/structlog/issues/425) for a more complete example.


### PR DESCRIPTION
# Summary

Recipe for passing context to worker threads as described over at https://github.com/hynek/structlog/issues/425.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
