### PR TITLE
Adds `log()` and `alog()` to `FilteringBoundLogger`.

### DIFF
--- a/src/structlog/typing.py
+++ b/src/structlog/typing.py
@@ -293,6 +293,11 @@ class FilteringBoundLogger(BindableLogger, Protocol):
         Log ``event % args`` with **kw** at **info** level.
         """
 
+    async def amsg(self, event: str, *args: Any, **kw: Any) -> Any:
+        """
+        Log ``event % args`` with **kw** at **info** level.
+        """
+
     def log(self, level: int, event: str, *args: Any, **kw: Any) -> Any:
         """
         Log ``event % args`` with **kw** at *level*.

--- a/src/structlog/typing.py
+++ b/src/structlog/typing.py
@@ -292,3 +292,13 @@ class FilteringBoundLogger(BindableLogger, Protocol):
         """
         Log ``event % args`` with **kw** at **info** level.
         """
+
+    def log(self, level: int, event: str, *args: Any, **kw: Any) -> Any:
+        """
+        Log ``event % args`` with **kw** at *level*.
+        """
+
+    async def alog(self, level: int, event: str, *args: Any, **kw: Any) -> Any:
+        """
+        Log ``event % args`` with **kw** at *level*.
+        """

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -292,6 +292,21 @@ def typecheck_filtering_return() -> None:
     fblog.warn("no value unbound because key not defined")
     fblog = fblog.new(new="value")
     fblog.info("this is a whole new logger")
+    fblog.log(logging.CRITICAL, "this is synchronously CRITICAL")
+
+
+async def typecheck_filtering_return_async() -> None:
+    fblogger: FilteringBoundLogger = structlog.get_logger(__name__)
+    await fblogger.adebug("async debug")
+    await fblogger.ainfo("async info")
+    await fblogger.awarning("async warning")
+    await fblogger.awarn("async warn")
+    await fblogger.aerror("async error")
+    await fblogger.afatal("fatal error")
+    await fblogger.aexception("async exception")
+    await fblogger.acritical("async critical")
+    await fblogger.amsg("async msg")
+    await fblogger.alog(logging.CRITICAL, "async log")
 
 
 # Structured tracebacks and ExceptionRenderer with ExceptionDictTransformer


### PR DESCRIPTION
Closes #460

# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
