### PR TITLE
Fix missing exception info in aexception()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ You can find out backwards-compatibility policy [here](https://github.com/hynek/
   This prevents crashes if the actual Exception is passed for the *exc_info* argument instead of a tuple or `True`.
   [#482](https://github.com/hynek/structlog/issues/482)
 
-- `aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio
-  executor (where original exception info is no longer available).
+- `aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio executor (where original exception info is no longer available).
   [#488](https://github.com/hynek/structlog/issues/488)
+
 
 ## [22.3.0](https://github.com/hynek/structlog/compare/22.2.0...22.3.0) - 2022-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ You can find out backwards-compatibility policy [here](https://github.com/hynek/
   This prevents crashes if the actual Exception is passed for the *exc_info* argument instead of a tuple or `True`.
   [#482](https://github.com/hynek/structlog/issues/482)
 
+- `aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio
+  executor (where original exception info is no longer available).
+  [#488](https://github.com/hynek/structlog/issues/488)
 
 ## [22.3.0](https://github.com/hynek/structlog/compare/22.2.0...22.3.0) - 2022-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ You can find out backwards-compatibility policy [here](https://github.com/hynek/
   This prevents crashes if the actual Exception is passed for the *exc_info* argument instead of a tuple or `True`.
   [#482](https://github.com/hynek/structlog/issues/482)
 
-- `aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio executor (where original exception info is no longer available).
+- `FilteringBoundLogger.aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio executor (where original exception info is no longer available).
   [#488](https://github.com/hynek/structlog/issues/488)
 
 

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import logging
+import sys
 
 from typing import Any, Callable
 
@@ -86,7 +87,10 @@ def exception(self: FilteringBoundLogger, event: str, **kw: Any) -> Any:
 
 
 async def aexception(self: FilteringBoundLogger, event: str, **kw: Any) -> Any:
-    kw.setdefault("exc_info", True)
+    # Exception info has to be extracted this early, because it is no longer
+    # available once control is passed to the executor.
+    if kw.get("exc_info", True) is True:
+        kw["exc_info"] = sys.exc_info()
 
     ctx = contextvars.copy_context()
     return await asyncio.get_running_loop().run_in_executor(

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -197,9 +197,9 @@ class TestFilteringLogger:
             await bl.aexception("foo")
             exc = e
 
-        assert len(cl.calls) == 1
-        assert type(cl.calls[0][2]["exc_info"]) == tuple
-        assert cl.calls[0][2]["exc_info"][1] is exc
+        assert 1 == len(cl.calls)
+        assert tuple == type(cl.calls[0][2]["exc_info"])
+        assert exc == cl.calls[0][2]["exc_info"][1]
 
     async def test_async_exception_true(self, bl, cl):
         """
@@ -212,9 +212,9 @@ class TestFilteringLogger:
             await bl.aexception("foo", exc_info=True)
             exc = e
 
-        assert len(cl.calls) == 1
-        assert type(cl.calls[0][2]["exc_info"]) == tuple
-        assert cl.calls[0][2]["exc_info"][1] is exc
+        assert 1 == len(cl.calls)
+        assert tuple == type(cl.calls[0][2]["exc_info"])
+        assert exc is cl.calls[0][2]["exc_info"][1]
 
     def test_exception_passed(self, bl, cl):
         """

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -198,7 +198,7 @@ class TestFilteringLogger:
             exc = e
 
         assert 1 == len(cl.calls)
-        assert tuple == type(cl.calls[0][2]["exc_info"])
+        assert isinstance(cl.calls[0][2]["exc_info"], tuple)
         assert exc == cl.calls[0][2]["exc_info"][1]
 
     async def test_async_exception_true(self, bl, cl):
@@ -213,7 +213,7 @@ class TestFilteringLogger:
             exc = e
 
         assert 1 == len(cl.calls)
-        assert tuple == type(cl.calls[0][2]["exc_info"])
+        assert isinstance(cl.calls[0][2]["exc_info"], tuple)
         assert exc is cl.calls[0][2]["exc_info"][1]
 
     def test_exception_passed(self, bl, cl):

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -188,12 +188,33 @@ class TestFilteringLogger:
 
     async def test_async_exception(self, bl, cl):
         """
-        exception ensures that exc_info is set to True, unless it's already
+        aexception sets exc_info to current exception info, if it's not already
         set.
         """
-        await bl.aexception("boom")
+        try:
+            raise Exception("boom")
+        except Exception as e:
+            await bl.aexception("foo")
+            exc = e
 
-        assert [("error", (), {"event": "boom", "exc_info": True})] == cl.calls
+        assert len(cl.calls) == 1
+        assert type(cl.calls[0][2]["exc_info"]) == tuple
+        assert cl.calls[0][2]["exc_info"][1] is exc
+
+    async def test_async_exception_true(self, bl, cl):
+        """
+        aexception replaces exc_info with current exception info, if exc_info
+        is True.
+        """
+        try:
+            raise Exception("boom")
+        except Exception as e:
+            await bl.aexception("foo", exc_info=True)
+            exc = e
+
+        assert len(cl.calls) == 1
+        assert type(cl.calls[0][2]["exc_info"]) == tuple
+        assert cl.calls[0][2]["exc_info"][1] is exc
 
     def test_exception_passed(self, bl, cl):
         """
@@ -205,7 +226,8 @@ class TestFilteringLogger:
 
     async def test_async_exception_passed(self, bl, cl):
         """
-        exception if exc_info has a value, exception doesn't tamper with it.
+        exception if exc_info has a value (other than True), exception doesn't
+        tamper with it.
         """
         await bl.aexception("boom", exc_info=42)
 


### PR DESCRIPTION
# Summary

This is how I've solved #488 for my needs.

I've not updated the test cases. I can do it, if you're happy with this change.

