### PR TITLE
Add async log variants to structlog.stdlib.BoundLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find out backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/22.3.0...HEAD)
 
+### Added
+
+- `structlog.stdlib.BoundLogger` now has, analogously to our native logger, a full set of async log methods prefixed with an `a`: `await log.ainfo("event!")`
+
+
 ### Fixed
 
 - ConsoleRenderer now reuses the `_figure_out_exc_info` to process the `exc_info` argument like `ExceptionRenderer` does.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,7 +277,7 @@ API Reference
 .. autofunction:: get_logger
 
 .. autoclass:: BoundLogger
-   :members: bind, unbind, try_unbind, new, debug, info, warning, warn, error, critical, exception, log
+   :members: bind, unbind, try_unbind, new, debug, info, warning, warn, error, critical, exception, log, adebug, ainfo, awarning, aerror, acritical, aexception, alog
 
 .. autoclass:: AsyncBoundLogger
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -225,25 +225,22 @@ As noted before, the fastest way to transform *structlog* into a `logging`-frien
 
 ## asyncio
 
-*structlog* comes with two approaches to support asynchronous logging.
-
-The default *bound logger* that you get back from {func}`structlog.get_logger()` doesn't have just the familiar log methods like `debug()` or `info()`, but also their async cousins, that simply prefix the name with an a:
+The default *bound logger* that you get back from {func}`structlog.get_logger()` and standard library's {class}`structlog.stdlib.BoundLogger` don't have just the familiar log methods like `debug()` or `info()`, but also their async cousins, that simply prefix the name with an a:
 
 ```pycon
 >>> import asyncio
 >>> logger = structlog.get_logger()
 >>> async def f():
-...     await logger.ainfo("hi!")
+...     await logger.ainfo("async hi!")
 ...
+>>> logger.info("Loop isn't running yet, but we can log!")
+2023-04-06 07:25:48 [info     ] Loop isn't running yet, but we can log!
 >>> asyncio.run(f())
-2022-10-18 13:23:37 [info     ] hi!
+2023-04-06 07:26:08 [info     ] async hi!
 ```
 
 You can use the sync and async logging methods interchangeably within the same application.
 
----
-
-The standard library integration on the other hand offers an asynchronous wrapper class {class}`structlog.stdlib.AsyncBoundLogger`.
 
 ## Liked what you saw?
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -48,12 +48,28 @@ See also {doc}`typing`.
 
 ### `asyncio`
 
-For `asyncio` applications, you may not want your whole application to block while your processor chain is formatting your log entries.
-For that use case *structlog* comes with {class}`structlog.stdlib.AsyncBoundLogger` that will do all processing in a thread pool executor.
+For `asyncio` applications, you may not want your whole application to block while the processor chain is formatting your log entries.
 
-This means an increased computational cost per log entry but your application will never block because of logging.
+For that use case *structlog* comes with a set of non-standard methods that will do all processing in a thread pool executor.
+They have the same names as the regular methods, except they are prefixed by an `a`.
+So instead of `logger.info("event!")` you write `await logger.ainfo("event!)`.
+No extra configuration is necessary and you can mix-and-match both types of methods within the same application.
+
+This means an increased computational cost per log entry, but your application will not block because of logging.
+
+```{versionadded} 23.1.0
+```
+
+---
+
+
+*structlog* also comes with {class}`structlog.stdlib.AsyncBoundLogger` that blankly makes all logging methods asynchronous (i.e. `await log.info()`).
 
 To use it, {doc}`configure <configuration>` *structlog* to use `AsyncBoundLogger` as `wrapper_class`.
+
+```{versionadded} 20.2.0
+```
+
 
 
 ## Processors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ docs = [
     "sphinx",
     "sphinx-notfound-page",
     "sphinxcontrib-mermaid",
+    "sphinxcontrib.asyncio",
     "twisted",
 ]
 dev = ["structlog[tests,typing,docs]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ docs = [
     "sphinx",
     "sphinx-notfound-page",
     "sphinxcontrib-mermaid",
-    "sphinxcontrib.asyncio",
     "twisted",
 ]
 dev = ["structlog[tests,typing,docs]"]

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -15,16 +15,10 @@ from structlog.contextvars import (
     clear_contextvars,
     merge_contextvars,
 )
-from structlog.testing import CapturingLogger
-
-
-@pytest.fixture(name="cl")
-def fixture_cl():
-    return CapturingLogger()
 
 
 @pytest.fixture(name="bl")
-def fixture_bl(cl):
+def _bl(cl):
     return make_filtering_bound_logger(logging.INFO)(cl, [], {})
 
 
@@ -79,7 +73,7 @@ class TestFilteringLogger:
 
     def test_no_args(self, bl, cl):
         """
-        If no args are passed, don't attempt intepolation.
+        If no args are passed, don't attempt interpolation.
 
         See also #473
         """
@@ -89,7 +83,7 @@ class TestFilteringLogger:
 
     async def test_async_no_args(self, bl, cl):
         """
-        If no args are passed, don't attempt intepolation.
+        If no args are passed, don't attempt interpolation.
 
         See also #473
         """

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 [testenv:pre-commit]
 skip_install = true
 deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
+commands = pre-commit run --all-files
 
 
 [testenv:mypy]

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -309,6 +309,18 @@ async def typecheck_filtering_return_async() -> None:
     await fblogger.alog(logging.CRITICAL, "async log")
 
 
+async def typecheck_stdlib_async() -> None:
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+    await logger.adebug("async debug")
+    await logger.ainfo("async info")
+    await logger.awarning("async warning")
+    await logger.aerror("async error")
+    await logger.afatal("fatal error")
+    await logger.aexception("async exception")
+    await logger.acritical("async critical")
+    await logger.alog(logging.CRITICAL, "async log")
+
+
 # Structured tracebacks and ExceptionRenderer with ExceptionDictTransformer
 struct_tb: structlog.tracebacks.Trace = structlog.tracebacks.extract(
     ValueError, ValueError("onoes"), None


### PR DESCRIPTION
# Summary

This seems the better approach than AsyncBoundLogger.


# Pull Request Check List

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
