### PR TITLE
Fix/logfmtrenderer quotes escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ You can find out backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/23.1.0...HEAD)
 
+### Fixed
+- `structlog.processors.LogfmtRenderer` now correctly renders escaped double quotes.
+  [#511](https://github.com/hynek/structlog/issues/511)
 
 ## [23.1.0](https://github.com/hynek/structlog/compare/22.3.0...23.1.0) - 2023-04-06
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -16,10 +16,10 @@ import json
 import logging
 import operator
 import os
+import re
 import sys
 import threading
 import time
-import re
 
 from typing import (
     Any,
@@ -169,8 +169,8 @@ class LogfmtRenderer:
         return " ".join(elements)
 
     def _escape_double_quotes(self, text: str) -> str:
-        value = f"{text}".replace(r'\"', r'\\\"')
-        return self._double_quotes_without_backslash_prefix.sub(r'\"', value)
+        value = f"{text}".replace(r"\"", r"\\\"")
+        return self._double_quotes_without_backslash_prefix.sub(r"\"", value)
 
 
 def _items_sorter(

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -214,8 +214,9 @@ def _items_sorter(
             return sorted(event_dict.items())
 
     else:
-        ordered_items = operator.methodcaller("items")
-
+        ordered_items = operator.methodcaller(  # type: ignore[assignment]
+            "items"
+        )
     return ordered_items
 
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -141,7 +141,9 @@ class LogfmtRenderer:
         self.bool_as_flag = bool_as_flag
         self._double_quotes_without_backslash_prefix = re.compile(r'(?<!\\)"')
 
-    def __call__(self, _: WrappedLogger, __: str, event_dict: EventDict) -> str:
+    def __call__(
+        self, _: WrappedLogger, __: str, event_dict: EventDict
+    ) -> str:
         elements: list[str] = []
         for key, value in self._ordered_items(event_dict):
             if any(c <= " " for c in key):
@@ -217,6 +219,7 @@ def _items_sorter(
         ordered_items = operator.methodcaller(  # type: ignore[assignment]
             "items"
         )
+
     return ordered_items
 
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -167,8 +167,8 @@ class LogfmtRenderer:
         return " ".join(elements)
 
     def _escape_double_quotes(self, text: str) -> str:
-        value = f"{text}".replace(r"\"", r"\\\"")
-        return self._double_quotes_without_backslash_prefix.sub(r"\"", value)
+        value = f"{text}".replace(r'\"', r'\\\"')
+        return self._double_quotes_without_backslash_prefix.sub(r'\"', value)
 
 
 def _items_sorter(

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -276,6 +276,16 @@ class TestLogfmtRenderer:
             == rv
         )
 
+    def test_double_quotes_escaping(self):
+        """
+        Text containing double quotes and escaped double quotes
+        should be rendered correctly
+        """
+        string_with_quotes = r'"example": "this \"should\" work!"'
+        event_dict = {"exception": string_with_quotes}
+        rv = LogfmtRenderer()(None, None, event_dict)
+        assert r'exception="\"example\": \"this \\\"should\\\" work!\""' == rv
+
     def test_invalid_key(self):
         """
         Keys cannot contain space characters.


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
PR to fix escaping double quotes in LogfmtRenderer
(fix https://github.com/hynek/structlog/issues/511 )

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
