### PR TITLE
Remove duplicated CallsiteParameterAdder processor configurations

### DIFF
--- a/typing_examples.py
+++ b/typing_examples.py
@@ -77,9 +77,6 @@ formatter = structlog.stdlib.ProcessorFormatter(
             set(CallsiteParameter), ["threading"]
         ),
         structlog.processors.CallsiteParameterAdder(
-            set(CallsiteParameter), additional_ignores=["threading"]
-        ),
-        structlog.processors.CallsiteParameterAdder(
             parameters=set(CallsiteParameter), additional_ignores=["threading"]
         ),
         structlog.processors.CallsiteParameterAdder(

--- a/typing_examples.py
+++ b/typing_examples.py
@@ -96,13 +96,6 @@ formatter = structlog.stdlib.ProcessorFormatter(
                 CallsiteParameter.LINENO,
             ]
         ),
-        structlog.processors.CallsiteParameterAdder(
-            parameters=[
-                CallsiteParameter.FILENAME,
-                CallsiteParameter.FUNC_NAME,
-                CallsiteParameter.LINENO,
-            ]
-        ),
     ],
 )
 


### PR DESCRIPTION
Removes redundant configurations of the CallsiteParameterAdder processor that were unnecessarily repeated in the example code.# Summary

<!-- Please tell us what your pull request is about here. -->

# Summary

This pull request removes redundant and meaningless configurations of the `structlog.processors.CallsiteParameterAdder` processor in the example code. Specifically, these changes are as follows:

1. Removed the duplicate configurations of `structlog.processors.CallsiteParameterAdder` with the same parameters (`FILENAME`, `FUNC_NAME`, `LINENO`).
- Users are already aware that they can input the same parameters through other repetitions, so this example is unnecessary.
- This duplicated example code may confuse users and lead them into an unnecessary attempt to find differences.

https://github.com/hynek/structlog/blob/ade1f4b10f361a7ba126e72111d455c1c50779e6/typing_examples.py#L92-L105

2. Removed the meaningless keyword argument example in `structlog.processors.CallsiteParameterAdder` configuration (`set(CallsiteParameter), additional_ignores=["threading"]`).
- This example is not necessary for the specification description of this library.
- The coexistence of keyword arguments and positional arguments is a description of Python's specifications.

https://github.com/hynek/structlog/blob/ade1f4b10f361a7ba126e72111d455c1c50779e6/typing_examples.py#L76-L84

These changes will improve the readability and maintainability of the example code by eliminating unnecessary repetitions and providing clearer examples of `structlog.processors.CallsiteParameterAdder` usage.

# Pull Request Check List

- [ x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x ] **New APIs** are added to [`typing_examples.py`](https://github.com/hynek/structlog/blob/main/tests/typing_examples.py).
- [x] Updated **documentation** for changed code.
    - [x ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [○] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.