### PR TITLE
Fix "default" TimeStamper args in docs/getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ structlog.configure(
         structlog.processors.add_log_level,
         structlog.processors.StackInfoRenderer(),
         structlog.dev.set_exc_info,
-        structlog.processors.TimeStamper(),
+        structlog.processors.TimeStamper(fmt='%Y-%m-%d %H:%M:%S', utc=False),
         structlog.dev.ConsoleRenderer()
     ],
     wrapper_class=structlog.make_filtering_bound_logger(logging.NOTSET),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ structlog.configure(
         structlog.processors.add_log_level,
         structlog.processors.StackInfoRenderer(),
         structlog.dev.set_exc_info,
-        structlog.processors.TimeStamper(fmt='%Y-%m-%d %H:%M:%S', utc=False),
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
         structlog.dev.ConsoleRenderer()
     ],
     wrapper_class=structlog.make_filtering_bound_logger(logging.NOTSET),


### PR DESCRIPTION
A small docs fix (:
