### PR TITLE
Minor typo fixes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ Whenever you bind or unbind data to a *bound logger*, this class is instantiated
 
 ### Logger Factories
 
-We've already talked about wrapped loggers responsible for the output, but until now we haven't explained where they come from until now.
+We've already talked about wrapped loggers responsible for the output, but we haven't explained where they come from until now.
 Unlike with *bound loggers*, you often need more flexibility when instantiating them.
 Therefore you don't configure a class; you configure a *factory* using the `logger_factory` keyword.
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -12,7 +12,7 @@ Please note that recipes related to integration with frameworks have an [own cha
 The name of the event is hard-coded in *structlog* to `event`.
 But that doesn't mean it has to be called that in your logs.
 
-With the {class}`structlog.processors.EventRenamer` processor you can for instance rename  the log message to `msg` and use `event` for something custom, that you bind to `_event` in your code:
+With the {class}`structlog.processors.EventRenamer` processor, you can, for instance, rename  the log message to `msg` and use `event` for something custom, that you bind to `_event` in your code:
 
 ```pycon
 >>> from structlog.processors import EventRenamer

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -189,7 +189,7 @@ structlog.configure(
         # sys.exc_info() tuple, remove "exc_info" and render the exception
         # with traceback into the "exception" key.
         structlog.processors.format_exc_info,
-        # If some value is in bytes, decode it to a unicode str.
+        # If some value is in bytes, decode it to a Unicode str.
         structlog.processors.UnicodeDecoder(),
         # Add callsite parameters.
         structlog.processors.CallsiteParameterAdder(


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).

      The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
