### PR TITLE
Make instances of BoundLoggerLazyProxy BindableLoggers on Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/23.2.0...HEAD)
 
+### Fixed
+
+- The return value from `get_logger()` (a `BoundLoggerLazyProxy`) now passes `isinstance`-checks against `structlog.typing.BindableLogger` on Python 3.12.
+
+
 
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 

--- a/src/structlog/_config.py
+++ b/src/structlog/_config.py
@@ -315,6 +315,11 @@ class BoundLoggerLazyProxy:
     .. versionchanged:: 0.4.0 Added support for *logger_factory_args*.
     """
 
+    # fulfill BindableLogger protocol without carrying accidental state
+    @property
+    def _context(self) -> dict[str, str]:
+        return {}
+
     def __init__(
         self,
         logger: WrappedLogger | None,

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -119,7 +119,7 @@ def as_immutable(logger: TLLogger) -> TLLogger:
     """
     _deprecated()
     if isinstance(logger, BoundLoggerLazyProxy):
-        logger = logger.bind()  # type: ignore[assignment]
+        logger = logger.bind()
 
     try:
         ctx = logger._context._tl.dict_.__class__(  # type: ignore[union-attr]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ from structlog._config import (
     get_logger,
     wrap_logger,
 )
+from structlog.typing import BindableLogger
 
 
 @pytest.fixture(name="proxy")
@@ -54,6 +55,16 @@ def test_lazy_logger_is_not_detected_as_abstract_method():
         log = structlog.get_logger()
 
     Foo()
+
+
+def test_lazy_logger_is_an_instance_of_bindable_logger():
+    """
+    The BoundLoggerLazyProxy returned by get_logger fulfills the BindableLogger
+    protocol.
+
+    See https://github.com/hynek/structlog/issues/560
+    """
+    assert isinstance(get_logger(), BindableLogger)
 
 
 def test_default_context_class():


### PR DESCRIPTION
Fixes #560

