### PR TITLE
Added `AddCallingClassPath` processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Added
 
+- `structlog.processors.AddCallingClassPath()` added, which will attempt to determine the calling class path and add it as `class_path` to the event dict. Takes an optional `levels` `list`|`set` to limit which `logging.LEVEL` to include the addition in.
+
 - Async log methods (those starting with an `a`) now also support the collection of callsite information using `structlog.processors.CallsiteParameterAdder`.
   [#565](https://github.com/hynek/structlog/issues/565)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -278,6 +278,8 @@ API Reference
 
 .. autoclass:: CallsiteParameterAdder
 
+.. autoclass:: AddCallingClassPath
+
 
 `structlog.stdlib` Module
 -------------------------

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -961,13 +961,17 @@ class AddCallingClassPath:
         """
         identified_path: str = frame.f_code.co_name
 
-        for cls in (
+        # pull out classes from the frames `f_globals` for testing against
+        for cls in {
             obj for obj in frame.f_globals.values() if inspect.isclass(obj)
-        ):
+        }:
             member = getattr(cls, frame.f_code.co_name, None)
+            # store the current path as a fall back (probably the path)
             identified_path = f"{cls.__module__}.{frame.f_code.co_name}"
             if inspect.isfunction(member) and member.__code__ == frame.f_code:
                 identified_path = f"{member.__module__}.{member.__qualname__}"
+                # we found our code match, can stop looking
                 break
 
+        # return our identified class path
         return identified_path

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -959,12 +959,13 @@ class AddCallingClassPath:
 
         .. versionadded:: 23.3.0
         """
+        default_path = '__main__'
         for cls in (
             obj for obj in frame.f_globals.values() if inspect.isclass(obj)
         ):
             member = getattr(cls, frame.f_code.co_name, None)
+            default_path = cls.__module__
             if inspect.isfunction(member) and member.__code__ == frame.f_code:
                 return f"{member.__module__}.{member.__qualname__}"
 
-        # No cover, code is reached but coverage doesn't recognize it.
-        return f"__main__.{frame.f_code.co_name}"  # pragma: no cover
+        return f"{default_path}.{frame.f_code.co_name}"

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 
+from types import FrameType
 from typing import (
     Any,
     Callable,
@@ -909,3 +910,60 @@ class EventRenamer:
                 event_dict["event"] = replace_by
 
         return event_dict
+
+
+class AddCallingClassPath:
+    """
+    Attempt to identify and add the caller class path to the event dict
+    under the ``class_path`` key.
+
+    Arguments:
+
+        levels:
+            A set of log levels to add the ``class_path`` key and
+            information to. An empty set == *
+
+    .. versionadded:: 23.3.0
+    """
+
+    def __init__(self, levels: set[str] | list[str] | None = None):
+        self.levels = levels
+
+    def __call__(
+        self, logger: WrappedLogger, name: str, event_dict: EventDict
+    ) -> EventDict:
+        if self.levels and name not in self.levels:
+            return event_dict
+
+        f, _ = _find_first_app_frame_and_name()
+        event_dict["class_path"] = self.get_qual_name(f)
+
+        return event_dict
+
+    def get_qual_name(self, frame: FrameType) -> str:
+        """
+            For a given app frame, attempt to deduce the class path
+            by crawling through the frame's ``f_globals`` to find matching object code.
+
+            This O(n) procedure should return as O(1) in most situations,
+            but buyer beware.
+
+            Arguments:
+
+                frame:
+                    Frame to process.
+
+            Returns:
+
+                string of the deduced class path
+
+        .. versionadded:: 23.3.0
+        """
+        for cls in (
+            obj for obj in frame.f_globals.values() if inspect.isclass(obj)
+        ):
+            member = getattr(cls, frame.f_code.co_name, None)
+            if inspect.isfunction(member) and member.__code__ == frame.f_code:
+                return f"{member.__module__}.{member.__qualname__}"
+
+        return f"__main__.{frame.f_code.co_name}"

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -959,13 +959,14 @@ class AddCallingClassPath:
 
         .. versionadded:: 23.3.0
         """
-        default_path = '__main__'
+        identified_path = None
         for cls in (
             obj for obj in frame.f_globals.values() if inspect.isclass(obj)
         ):
             member = getattr(cls, frame.f_code.co_name, None)
-            default_path = cls.__module__
+            identified_path = f"{cls.__module__}.{frame.f_code.co_name}"
             if inspect.isfunction(member) and member.__code__ == frame.f_code:
-                return f"{member.__module__}.{member.__qualname__}"
+                identified_path = f"{member.__module__}.{member.__qualname__}"
+                break
 
-        return f"{default_path}.{frame.f_code.co_name}"
+        return identified_path

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -966,4 +966,5 @@ class AddCallingClassPath:
             if inspect.isfunction(member) and member.__code__ == frame.f_code:
                 return f"{member.__module__}.{member.__qualname__}"
 
-        return f"__main__.{frame.f_code.co_name}"
+        # No cover, code is reached but coverage doesn't recognize it.
+        return f"__main__.{frame.f_code.co_name}"  # pragma: no cover

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -959,7 +959,8 @@ class AddCallingClassPath:
 
         .. versionadded:: 23.3.0
         """
-        identified_path = None
+        identified_path: str = frame.f_code.co_name
+
         for cls in (
             obj for obj in frame.f_globals.values() if inspect.isclass(obj)
         ):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1219,6 +1219,23 @@ class TestAddCallingClassPath:
             == json.loads(cf.logger.calls.pop().args[0])["class_path"]
         )
 
+    def test_level_limitor(self):
+        """
+        Ensure `AddCallingClassPath` Processor limits which levels
+        that the ``class_path`` details are added to
+        """
+        cf = structlog.testing.CapturingLoggerFactory()
+        structlog.configure(
+            logger_factory=cf,
+            processors=[
+                structlog.processors.AddCallingClassPath(levels={"debug"}),
+                structlog.processors.JSONRenderer(),
+            ],
+        )
+        structlog.get_logger().info("test!")
+        # limiter is set to 'debug', so 'info' should not get the param added
+        assert "class_path" not in json.loads(cf.logger.calls.pop().args[0])
+
     async def test_async_processor(self):
         """
         Ensure `AddCallingClassPath` Processor can be enabled, and


### PR DESCRIPTION
# Summary

Added a `class_path` event entry processor as `AddCallingClassPath` (#386, #492).

Takes an optional `set` or `list` to limit which logging levels to add this at, as lookups potentially can add overhead (though should run in N(1)).

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!

  There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.

  This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).

      The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
