### PR TITLE
Migrated from `event_loop` fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `structlog.threadlocal.tmp_bind()` now also works with `BoundLoggerLazyProxy` (in other words: before anything is bound to a bound logger).
 
-- Migrated tests away from depreciated `event_loop` usage to per recommendations from `pytest-asyncio`.
-  [pytest-dev/pytest-asyncio#638](https://github.com/pytest-dev/pytest-asyncio/issues/638)
-
 
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `structlog.threadlocal.tmp_bind()` now also works with `BoundLoggerLazyProxy` (in other words: before anything is bound to a bound logger).
 
+- Migrated tests away from depreciated `event_loop` usage to per recommendations from `pytest-asyncio`.
+  [pytest-dev/pytest-asyncio#638](https://github.com/pytest-dev/pytest-asyncio/issues/638)
+
 
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -33,11 +33,12 @@ def _clear_contextvars():
 
 
 class TestContextvars:
-    async def test_bind(self, event_loop):
+    async def test_bind(self):
         """
         Binding a variable causes it to be included in the result of
         merge_contextvars.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -45,11 +46,12 @@ class TestContextvars:
 
         assert {"a": 1, "b": 2} == await event_loop.create_task(coro())
 
-    async def test_multiple_binds(self, event_loop):
+    async def test_multiple_binds(self):
         """
         Multiple calls to bind_contextvars accumulate values instead of
         replacing them. But they override redefined ones.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1, c=3)
@@ -63,11 +65,12 @@ class TestContextvars:
             "d": 4,
         } == await event_loop.create_task(coro())
 
-    async def test_reset(self, event_loop):
+    async def test_reset(self):
         """
         reset_contextvars allows resetting contexvars to
         previously-set values.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -87,10 +90,11 @@ class TestContextvars:
 
         await event_loop.create_task(coro())
 
-    async def test_nested_async_bind(self, event_loop):
+    async def test_nested_async_bind(self):
         """
         Context is passed correctly between "nested" concurrent operations.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -102,22 +106,24 @@ class TestContextvars:
 
         assert {"a": 1, "b": 2, "c": 3} == await event_loop.create_task(coro())
 
-    async def test_merge_works_without_bind(self, event_loop):
+    async def test_merge_works_without_bind(self):
         """
         merge_contextvars returns values as normal even when there has
         been no previous calls to bind_contextvars.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             return merge_contextvars(None, None, {"b": 2})
 
         assert {"b": 2} == await event_loop.create_task(coro())
 
-    async def test_merge_overrides_bind(self, event_loop):
+    async def test_merge_overrides_bind(self):
         """
         Variables included in merge_contextvars override previously
         bound variables.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -125,11 +131,12 @@ class TestContextvars:
 
         assert {"a": 111, "b": 2} == await event_loop.create_task(coro())
 
-    async def test_clear(self, event_loop):
+    async def test_clear(self):
         """
         The context-local context can be cleared, causing any previously bound
         variables to not be included in merge_contextvars's result.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -138,11 +145,12 @@ class TestContextvars:
 
         assert {"b": 2} == await event_loop.create_task(coro())
 
-    async def test_clear_without_bind(self, event_loop):
+    async def test_clear_without_bind(self):
         """
         The context-local context can be cleared, causing any previously bound
         variables to not be included in merge_contextvars's result.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             clear_contextvars()
@@ -150,11 +158,12 @@ class TestContextvars:
 
         assert {} == await event_loop.create_task(coro())
 
-    async def test_unbind(self, event_loop):
+    async def test_unbind(self):
         """
         Unbinding a previously bound variable causes it to be removed from the
         result of merge_contextvars.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -163,10 +172,11 @@ class TestContextvars:
 
         assert {"b": 2} == await event_loop.create_task(coro())
 
-    async def test_unbind_not_bound(self, event_loop):
+    async def test_unbind_not_bound(self):
         """
         Unbinding a not bound variable causes doesn't raise an exception.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
 
         async def coro():
             # Since unbinding means "setting to Ellipsis", we have to make
@@ -177,11 +187,12 @@ class TestContextvars:
 
         assert {"b": 2} == await event_loop.create_task(coro())
 
-    async def test_parallel_binds(self, event_loop):
+    async def test_parallel_binds(self):
         """
         Binding a variable causes it to be included in the result of
         merge_contextvars.
         """
+        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         coro1_bind = asyncio.Event()
         coro2_bind = asyncio.Event()
 

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -38,7 +38,7 @@ class TestContextvars:
         Binding a variable causes it to be included in the result of
         merge_contextvars.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -51,7 +51,7 @@ class TestContextvars:
         Multiple calls to bind_contextvars accumulate values instead of
         replacing them. But they override redefined ones.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1, c=3)
@@ -70,7 +70,7 @@ class TestContextvars:
         reset_contextvars allows resetting contexvars to
         previously-set values.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -94,7 +94,7 @@ class TestContextvars:
         """
         Context is passed correctly between "nested" concurrent operations.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -111,7 +111,7 @@ class TestContextvars:
         merge_contextvars returns values as normal even when there has
         been no previous calls to bind_contextvars.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             return merge_contextvars(None, None, {"b": 2})
@@ -123,7 +123,7 @@ class TestContextvars:
         Variables included in merge_contextvars override previously
         bound variables.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -136,7 +136,7 @@ class TestContextvars:
         The context-local context can be cleared, causing any previously bound
         variables to not be included in merge_contextvars's result.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -150,7 +150,7 @@ class TestContextvars:
         The context-local context can be cleared, causing any previously bound
         variables to not be included in merge_contextvars's result.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             clear_contextvars()
@@ -163,7 +163,7 @@ class TestContextvars:
         Unbinding a previously bound variable causes it to be removed from the
         result of merge_contextvars.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             bind_contextvars(a=1)
@@ -176,7 +176,7 @@ class TestContextvars:
         """
         Unbinding a not bound variable causes doesn't raise an exception.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
 
         async def coro():
             # Since unbinding means "setting to Ellipsis", we have to make
@@ -192,7 +192,7 @@ class TestContextvars:
         Binding a variable causes it to be included in the result of
         merge_contextvars.
         """
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        event_loop = asyncio.get_running_loop()
         coro1_bind = asyncio.Event()
         coro2_bind = asyncio.Event()
 


### PR DESCRIPTION
While I was mucking with code, came across a coming depreciate from `pytest-asyncio` where they are deprecating using the `event_loop` fixture in favor of the more portable:
```python
        event_loop = asyncio.get_running_loop()
```

Migrated to this [recommended](https://github.com/pytest-dev/pytest-asyncio/issues/638) method.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!

  There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.

  This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).

      The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->