### PR TITLE
Make stdlib.BoundLogger.exception call Logger.exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `structlog.threadlocal.tmp_bind()` now also works with `BoundLoggerLazyProxy` (in other words: before anything is bound to a bound logger).
 
+- stdlib: `structlog.stdlib.BoundLogger.exception()`'s handling of`LogRecord.exc_info` is now set consistent with `logging`.
+  [#571](https://github.com/hynek/structlog/issues/571)
+  [#572](https://github.com/hynek/structlog/issues/572)
+
 
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -19,7 +19,7 @@ import sys
 import warnings
 
 from functools import partial
-from typing import Any, Callable, Collection, Iterable, Sequence, cast
+from typing import Any, Callable, Collection, Dict, Iterable, Sequence, cast
 
 from . import _config
 from ._base import BoundLoggerBase
@@ -1036,7 +1036,7 @@ class ProcessorFormatter(logging.Formatter):
             # We need to copy because it's possible that the same record gets
             # processed by multiple logging formatters. LogRecord.getMessage
             # would transform our dict into a str.
-            ed = cast(dict[str, Any], record.msg).copy()
+            ed = cast(Dict[str, Any], record.msg).copy()
             ed["_record"] = record
             ed["_from_structlog"] = True
         else:
@@ -1078,7 +1078,7 @@ class ProcessorFormatter(logging.Formatter):
 
         if not isinstance(ed, str):
             warnings.warn(
-                "The last processor in ProcessorFormatter.formatters must "
+                "The last processor in ProcessorFormatter.processors must "
                 f"return a string, but {self.processors[-1]} returned a "
                 f"{type(ed)} instead.",
                 category=RuntimeWarning,

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -16,9 +16,10 @@ import contextvars
 import functools
 import logging
 import sys
+import warnings
 
 from functools import partial
-from typing import Any, Callable, Collection, Iterable, Sequence
+from typing import Any, Callable, Collection, Iterable, Sequence, cast
 
 from . import _config
 from ._base import BoundLoggerBase
@@ -27,7 +28,14 @@ from ._log_levels import _LEVEL_TO_NAME, _NAME_TO_LEVEL, add_log_level
 from .contextvars import _ASYNC_CALLING_STACK, merge_contextvars
 from .exceptions import DropEvent
 from .processors import StackInfoRenderer
-from .typing import Context, EventDict, ExcInfo, Processor, WrappedLogger
+from .typing import (
+    Context,
+    EventDict,
+    ExcInfo,
+    Processor,
+    ProcessorReturnValue,
+    WrappedLogger,
+)
 
 
 __all__ = [
@@ -209,12 +217,11 @@ class BoundLogger(BoundLoggerBase):
         self, event: str | None = None, *args: Any, **kw: Any
     ) -> Any:
         """
-        Process event and call `logging.Logger.error` with the result,
-        after setting ``exc_info`` to `True`.
+        Process event and call `logging.Logger.exception` with the result,
+        after setting ``exc_info`` to `True` if it's not already set.
         """
         kw.setdefault("exc_info", True)
-
-        return self.error(event, *args, **kw)
+        return self._proxy_to_logger("exception", event, *args, **kw)
 
     def log(
         self, level: int, event: str | None = None, *args: Any, **kw: Any
@@ -1019,16 +1026,17 @@ class ProcessorFormatter(logging.Formatter):
         logger = getattr(record, "_logger", _SENTINEL)
         meth_name = getattr(record, "_name", "__structlog_sentinel__")
 
+        ed: ProcessorReturnValue
         if logger is not _SENTINEL and meth_name != "__structlog_sentinel__":
             # Both attached by wrap_for_formatter
             if self.logger is not None:
                 logger = self.logger
-            meth_name = record._name  # type: ignore[attr-defined]
+            meth_name = cast(str, record._name)  # type:ignore[attr-defined]
 
             # We need to copy because it's possible that the same record gets
-            # processed by multiple logging formatters.  LogRecord.getMessage
+            # processed by multiple logging formatters. LogRecord.getMessage
             # would transform our dict into a str.
-            ed = record.msg.copy()  # type: ignore[union-attr]
+            ed = cast(dict[str, Any], record.msg).copy()
             ed["_record"] = record
             ed["_from_structlog"] = True
         else:
@@ -1045,27 +1053,38 @@ class ProcessorFormatter(logging.Formatter):
 
             record.args = ()
 
-            # Add stack-related attributes to event_dict and unset them
-            # on the record copy so that the base implementation wouldn't
-            # append stacktraces to the output.
+            # Add stack-related attributes to the event dict
             if record.exc_info:
                 ed["exc_info"] = record.exc_info
             if record.stack_info:
                 ed["stack_info"] = record.stack_info
 
-            if not self.keep_exc_info:
-                record.exc_text = None
-                record.exc_info = None
-            if not self.keep_stack_info:
-                record.stack_info = None
-
             # Non-structlog allows to run through a chain to prepare it for the
             # final processor (e.g. adding timestamps and log levels).
             for proc in self.foreign_pre_chain or ():
-                ed = proc(logger, meth_name, ed)
+                ed = cast(EventDict, proc(logger, meth_name, ed))
+
+        # If required, unset stack-related attributes on the record copy so
+        # that the base implementation doesn't append stacktraces to the
+        # output.
+        if not self.keep_exc_info:
+            record.exc_text = None
+            record.exc_info = None
+        if not self.keep_stack_info:
+            record.stack_info = None
 
         for p in self.processors:
-            ed = p(logger, meth_name, ed)
+            ed = p(logger, meth_name, cast(EventDict, ed))
+
+        if not isinstance(ed, str):
+            warnings.warn(
+                "The last processor in ProcessorFormatter.formatters must "
+                f"return a string, but {self.processors[-1]} returned a "
+                f"{type(ed)} instead.",
+                category=RuntimeWarning,
+                stacklevel=1,
+            )
+            ed = cast(str, ed)
 
         record.msg = ed
 

--- a/src/structlog/typing.py
+++ b/src/structlog/typing.py
@@ -60,10 +60,14 @@ copy itself.
 .. versionadded:: 20.2.0
 """
 
-Processor = Callable[
-    [WrappedLogger, str, EventDict],
-    Union[Mapping[str, Any], str, bytes, bytearray, Tuple[Any, ...]],
+ProcessorReturnValue = Union[
+    Mapping[str, Any], str, bytes, bytearray, Tuple[Any, ...]
 ]
+"""
+A value returned by a processor.
+"""
+
+Processor = Callable[[WrappedLogger, str, EventDict], ProcessorReturnValue]
 """
 A callable that is part of the processor chain.
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -193,7 +193,8 @@ class TestFilterByLevel:
 
 class TestBoundLogger:
     @pytest.mark.parametrize(
-        ("method_name"), ["debug", "info", "warning", "error", "critical"]
+        ("method_name"),
+        ["debug", "info", "warning", "error", "exception", "critical"],
     )
     def test_proxies_to_correct_method(self, method_name):
         """
@@ -202,14 +203,6 @@ class TestBoundLogger:
         bl = BoundLogger(ReturnLogger(), [return_method_name], {})
 
         assert method_name == getattr(bl, method_name)("event")
-
-    def test_proxies_exception(self):
-        """
-        BoundLogger.exception is proxied to Logger.error.
-        """
-        bl = BoundLogger(ReturnLogger(), [return_method_name], {})
-
-        assert "error" == bl.exception("event")
 
     def test_proxies_log(self):
         """
@@ -1154,7 +1147,7 @@ class TestAsyncBoundLogger:
         """
         await getattr(abl.bind(foo="bar"), stdlib_log_method)("42")
 
-        aliases = {"exception": "error", "warn": "warning"}
+        aliases = {"warn": "warning"}
 
         alias = aliases.get(stdlib_log_method)
         expect = alias if alias else stdlib_log_method

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1144,7 +1144,7 @@ class TestProcessorFormatter:
 
         # This doesn't test ProcessorFormatter itself directly, but it's
         # relevant to setups where ProcessorFormatter is used, i.e. where
-        # handlers will receive LogRecord objects that come from both strutlog
+        # handlers will receive LogRecord objects that come from both structlog
         # and non-structlog loggers.
 
         records: Dict[  # noqa: UP006 - dict isn't generic until Python 3.9
@@ -1153,8 +1153,8 @@ class TestProcessorFormatter:
 
         class DummyHandler(logging.Handler):
             def emit(self, record):
-                # Don't do anything, just store the record in the records dict
-                # by its message so we can assert things about it
+                # Don't do anything; just store the record in the records dict
+                # by its message, so we can assert things about it.
                 if isinstance(record.msg, dict):
                     records[record.msg["event"]] = record
                 else:
@@ -1163,7 +1163,7 @@ class TestProcessorFormatter:
         stdlib_logger = logging.getLogger()
         structlog_logger = get_logger()
 
-        # It doesn't matter which logger we add the handler to here
+        # It doesn't matter which logger we add the handler to here.
         stdlib_logger.addHandler(DummyHandler())
 
         try:
@@ -1173,17 +1173,19 @@ class TestProcessorFormatter:
             structlog_logger.exception("baz")
 
         stdlib_record = records.pop("bar")
-        assert stdlib_record.msg == "bar"
-        assert stdlib_record.exc_info is not None
-        assert stdlib_record.exc_info[0] is Exception
-        assert stdlib_record.exc_info[1].args == ("foo",)
+
+        assert "bar" == stdlib_record.msg
+        assert stdlib_record.exc_info
+        assert Exception is stdlib_record.exc_info[0]
+        assert ("foo",) == stdlib_record.exc_info[1].args
 
         structlog_record = records.pop("baz")
-        assert structlog_record.msg["event"] == "baz"
-        assert structlog_record.msg["exc_info"] is True
-        assert structlog_record.exc_info is not None
-        assert structlog_record.exc_info[0] is Exception
-        assert structlog_record.exc_info[1].args == ("foo",)
+
+        assert "baz" == structlog_record.msg["event"]
+        assert True is structlog_record.msg["exc_info"]
+        assert structlog_record.exc_info
+        assert Exception is structlog_record.exc_info[0]
+        assert ("foo",) == structlog_record.exc_info[1].args
 
         assert not records
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1116,6 +1116,25 @@ class TestProcessorFormatter:
             {"foo": "bar", "_record": "foo", "_from_structlog": True},
         )
 
+    def test_non_string_message_warning(self):
+        """
+        A warning is raised if the last processor in
+        ProcessorFormatter.processors doesn't return a string.
+        """
+        configure_logging(None)
+        logger = logging.getLogger()
+
+        formatter = ProcessorFormatter(
+            processors=[lambda *args, **kwargs: {"foo": "bar"}],
+        )
+        logger.handlers[0].setFormatter(formatter)
+
+        with pytest.warns(
+            RuntimeWarning,
+            match="The last processor in ProcessorFormatter.processors must return a string",
+        ):
+            logger.info("baz")
+
 
 @pytest_asyncio.fixture(name="abl")
 async def _abl(cl):


### PR DESCRIPTION
# Summary

Closes #571 

It does these things:

- Makes the `structlog.stdlib.BoundLogger.exception` proxy to the wrapper `Logger`'s `exception` method, instead of `error`. This is useful for the niche use case of `Handler` classes that need to deal with both structlog and non-structlog records and prevents such handlers having to reconstruct `record.exc_info` for themselves or rely on structlog processors to do it
- Makes the handling of `ProcessorFormatter`'s `keep_exc_info` and `keep_stack_info` args consistent for log records originating from both structlog and non-structlog loggers.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] ~~**New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).~~
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
