### PR TITLE
Display "exception" logs as level "error"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - The lazy logger proxy returned by `structlog.get_logger()` now returns its initial values when asked for context.
   When asked for context before binding for the first time, it returned an empty dictionary in 23.3.0.
+
 - The displayed level name when using `structlog.stdlib.BoundLogger.exception()` is `"error"` instead of `"exception"`.
   Fixes regression in 23.3.0.
   [#584](https://github.com/hynek/structlog/issues/584)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - The lazy logger proxy returned by `structlog.get_logger()` now returns its initial values when asked for context.
   When asked for context before binding for the first time, it returned an empty dictionary in 23.3.0.
+- The displayed level name when using `structlog.stdlib.BoundLogger.exception()` is `"error"` instead of `"exception"`.
+  Fixes regression in 23.3.0.
+  [#584](https://github.com/hynek/structlog/issues/584)
 
 
 ## [23.3.0](https://github.com/hynek/structlog/compare/23.2.0...23.3.0) - 2023-12-29

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -60,10 +60,15 @@ def add_log_level(
     .. versionchanged:: 20.2.0
        Importable from `structlog.processors` (additionally to
        `structlog.stdlib`).
+    .. versionchanged:: 24.1.0
+       Added mapping from "exception" to "error"
     """
     if method_name == "warn":
         # The stdlib has an alias
         method_name = "warning"
+    if method_name == "exception":
+        # exception("") method is the same as error("", exc_info=True)
+        method_name = "error"
 
     event_dict["level"] = method_name
 

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -66,7 +66,7 @@ def add_log_level(
     if method_name == "warn":
         # The stdlib has an alias
         method_name = "warning"
-    if method_name == "exception":
+    elif method_name == "exception":
         # exception("") method is the same as error("", exc_info=True)
         method_name = "error"
 

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -488,13 +488,16 @@ class TestAddLogLevel:
 
         assert "error" == event_dict["level"]
 
-    def test_log_level_alias_normalized(self):
+    @pytest.mark.parametrize(
+        ("alias", "normalized"), [("warn", "warning"), ("exception", "error")]
+    )
+    def test_log_level_alias_normalized(self, alias, normalized):
         """
         The normalized name of the log level is added to the event dict.
         """
-        event_dict = add_log_level(None, "warn", {})
+        event_dict = add_log_level(None, alias, {})
 
-        assert "warning" == event_dict["level"]
+        assert normalized == event_dict["level"]
 
 
 @pytest.fixture(name="make_log_record")


### PR DESCRIPTION
# Summary

Changes the displayed log level added by the `add_log_level` processor for logs using the `exception()` method to `"error"` instead of `"exception"`. This replicates the behaviour of CPython and structlog pre-23.3.0 (#572).

This issue has been discussed in #584.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
