### PR TITLE
Escape newlines in LogfmtRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.1.0...HEAD)
 
+### Changed
+
+- `structlog.processors.LogfmtRenderer` now escapes newlines.
+  [#592](https://github.com/hynek/structlog/pull/592)
 
 ## [24.1.0](https://github.com/hynek/structlog/compare/23.3.0...24.1.0) - 2024-01-08
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -170,7 +170,7 @@ class LogfmtRenderer:
                     continue
                 value = "true" if value else "false"
 
-            value = f"{value}".replace('"', '\\"')
+            value = f"{value}".replace('"', '\\"').replace("\n", "\\n")
 
             if " " in value or "=" in value:
                 value = f'"{value}"'

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -290,6 +290,14 @@ class TestLogfmtRenderer:
         with pytest.raises(ValueError, match='Invalid key: "invalid key"'):
             LogfmtRenderer()(None, None, event_dict)
 
+    def test_newline_in_value(self):
+        """
+        Newlines in values should be escaped
+        """
+        event_dict = {"with_newline": "some\nvalue"}
+        rv = LogfmtRenderer()(None, None, event_dict)
+        assert r"with_newline=some\nvalue" == rv
+
 
 class TestJSONRenderer:
     def test_renders_json(self, event_dict):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -292,10 +292,12 @@ class TestLogfmtRenderer:
 
     def test_newline_in_value(self):
         """
-        Newlines in values should be escaped
+        Newlines in values are escaped.
         """
         event_dict = {"with_newline": "some\nvalue"}
+
         rv = LogfmtRenderer()(None, None, event_dict)
+
         assert r"with_newline=some\nvalue" == rv
 
 


### PR DESCRIPTION
# Summary

Currently, the LogfmtRenderer doesn't escape newlines, so any newline in a field (most commonly exceptions, but also other fields) ends up breaking the log over multiple lines, which messes up with log processing downstream.

This PR makes it so that newlines get escaped. I've checked that the behaviour is identical to the implementations in https://github.com/jteppinette/python-logfmter/ and https://github.com/sirupsen/logrus (which are the other logfmt implementations I happen to be using).


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
