### PR TITLE
Allow CallsiteParameterAdder to be pickled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - It is now possible to disable log level-padding in `structlog.dev.LogLevelColumnFormatter` and `structlog.dev.ConsoleRenderer`.
   [#599](https://github.com/hynek/structlog/pull/599)
 
+- The `structlog.processors.CallsiteParameterAdder` can now be pickled.
+  [#603](https://github.com/hynek/structlog/pull/603)
 
 
 ### Changed

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -724,39 +724,43 @@ class CallsiteParameter(enum.Enum):
     PROCESS_NAME = "process_name"
 
 
-def _pathname(module, frame_info) -> Any:
+def _get_callsite_pathname(module: str, frame_info: inspect.Traceback) -> Any:
     return frame_info.filename
 
 
-def _filename(module, frame_info) -> Any:
+def _get_callsite_filename(module: str, frame_info: inspect.Traceback) -> Any:
     return os.path.basename(frame_info.filename)
 
 
-def _module(module, frame_info) -> Any:
+def _get_callsite_module(module: str, frame_info: inspect.Traceback) -> Any:
     return os.path.splitext(os.path.basename(frame_info.filename))[0]
 
 
-def _func_name(module, frame_info) -> Any:
+def _get_callsite_func_name(module: str, frame_info: inspect.Traceback) -> Any:
     return frame_info.function
 
 
-def _lineno(module, frame_info) -> Any:
+def _get_callsite_lineno(module: str, frame_info: inspect.Traceback) -> Any:
     return frame_info.lineno
 
 
-def _thread(module, frame_info) -> Any:
+def _get_callsite_thread(module: str, frame_info: inspect.Traceback) -> Any:
     return threading.get_ident()
 
 
-def _thread_name(module, frame_info) -> Any:
+def _get_callsite_thread_name(
+    module: str, frame_info: inspect.Traceback
+) -> Any:
     return threading.current_thread().name
 
 
-def _process(module, frame_info) -> Any:
+def _get_callsite_process(module: str, frame_info: inspect.Traceback) -> Any:
     return os.getpid()
 
 
-def _process_name(module, frame_info) -> Any:
+def _get_callsite_process_name(
+    module: str, frame_info: inspect.Traceback
+) -> Any:
     return get_processname()
 
 
@@ -803,15 +807,15 @@ class CallsiteParameterAdder:
     _handlers: ClassVar[
         dict[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
     ] = {
-        CallsiteParameter.PATHNAME: _pathname,
-        CallsiteParameter.FILENAME: _filename,
-        CallsiteParameter.MODULE: _module,
-        CallsiteParameter.FUNC_NAME: _func_name,
-        CallsiteParameter.LINENO: _lineno,
-        CallsiteParameter.THREAD: _thread,
-        CallsiteParameter.THREAD_NAME: _thread_name,
-        CallsiteParameter.PROCESS: _process,
-        CallsiteParameter.PROCESS_NAME: _process_name,
+        CallsiteParameter.PATHNAME: _get_callsite_pathname,
+        CallsiteParameter.FILENAME: _get_callsite_filename,
+        CallsiteParameter.MODULE: _get_callsite_module,
+        CallsiteParameter.FUNC_NAME: _get_callsite_func_name,
+        CallsiteParameter.LINENO: _get_callsite_lineno,
+        CallsiteParameter.THREAD: _get_callsite_thread,
+        CallsiteParameter.THREAD_NAME: _get_callsite_thread_name,
+        CallsiteParameter.PROCESS: _get_callsite_process,
+        CallsiteParameter.PROCESS_NAME: _get_callsite_process_name,
     }
     _record_attribute_map: ClassVar[dict[CallsiteParameter, str]] = {
         CallsiteParameter.PATHNAME: "pathname",

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -723,6 +723,32 @@ class CallsiteParameter(enum.Enum):
     #: The name of the process the callsite was executed in.
     PROCESS_NAME = "process_name"
 
+def _pathname(module, frame_info) -> Any:
+    return frame_info.filename
+
+def _filename(module, frame_info) -> Any:
+    return os.path.basename(frame_info.filename)
+
+def _module(module, frame_info) -> Any:
+    return os.path.splitext(os.path.basename(frame_info.filename))[0]
+
+def _func_name(module, frame_info) -> Any:
+    return frame_info.function
+
+def _lineno(module, frame_info) -> Any:
+    return frame_info.lineno
+
+def _thread(module, frame_info) -> Any:
+    return threading.get_ident()
+
+def _thread_name(module, frame_info) -> Any:
+    return threading.current_thread().name
+
+def _process(module, frame_info) -> Any:
+    return os.getpid()
+
+def _process_name(module, frame_info) -> Any:
+    return get_processname()
 
 class CallsiteParameterAdder:
     """
@@ -767,33 +793,15 @@ class CallsiteParameterAdder:
     _handlers: ClassVar[
         dict[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
     ] = {
-        CallsiteParameter.PATHNAME: (
-            lambda module, frame_info: frame_info.filename
-        ),
-        CallsiteParameter.FILENAME: (
-            lambda module, frame_info: os.path.basename(frame_info.filename)
-        ),
-        CallsiteParameter.MODULE: (
-            lambda module, frame_info: os.path.splitext(
-                os.path.basename(frame_info.filename)
-            )[0]
-        ),
-        CallsiteParameter.FUNC_NAME: (
-            lambda module, frame_info: frame_info.function
-        ),
-        CallsiteParameter.LINENO: (
-            lambda module, frame_info: frame_info.lineno
-        ),
-        CallsiteParameter.THREAD: (
-            lambda module, frame_info: threading.get_ident()
-        ),
-        CallsiteParameter.THREAD_NAME: (
-            lambda module, frame_info: threading.current_thread().name
-        ),
-        CallsiteParameter.PROCESS: (lambda module, frame_info: os.getpid()),
-        CallsiteParameter.PROCESS_NAME: (
-            lambda module, frame_info: get_processname()
-        ),
+        CallsiteParameter.PATHNAME: _pathname,
+        CallsiteParameter.FILENAME: _filename,
+        CallsiteParameter.MODULE: _module,
+        CallsiteParameter.FUNC_NAME: _func_name,
+        CallsiteParameter.LINENO: _lineno,
+        CallsiteParameter.THREAD: _thread,
+        CallsiteParameter.THREAD_NAME: _thread_name,
+        CallsiteParameter.PROCESS: _process,
+        CallsiteParameter.PROCESS_NAME: _process_name,
     }
     _record_attribute_map: ClassVar[dict[CallsiteParameter, str]] = {
         CallsiteParameter.PATHNAME: "pathname",

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -723,32 +723,42 @@ class CallsiteParameter(enum.Enum):
     #: The name of the process the callsite was executed in.
     PROCESS_NAME = "process_name"
 
+
 def _pathname(module, frame_info) -> Any:
     return frame_info.filename
+
 
 def _filename(module, frame_info) -> Any:
     return os.path.basename(frame_info.filename)
 
+
 def _module(module, frame_info) -> Any:
     return os.path.splitext(os.path.basename(frame_info.filename))[0]
+
 
 def _func_name(module, frame_info) -> Any:
     return frame_info.function
 
+
 def _lineno(module, frame_info) -> Any:
     return frame_info.lineno
+
 
 def _thread(module, frame_info) -> Any:
     return threading.get_ident()
 
+
 def _thread_name(module, frame_info) -> Any:
     return threading.current_thread().name
+
 
 def _process(module, frame_info) -> Any:
     return os.getpid()
 
+
 def _process_name(module, frame_info) -> Any:
     return get_processname()
+
 
 class CallsiteParameterAdder:
     """

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -11,6 +11,7 @@ import itertools
 import json
 import logging
 import os
+import pickle
 import sys
 import threading
 
@@ -491,6 +492,17 @@ class TestCallsiteParameterAdder:
         expected = {"event": test_message, **callsite_params}
 
         assert expected == actual
+
+    def test_pickeable_callsite_parameter_adder(self) -> None:
+        """
+        An instance of ``CallsiteParameterAdder`` can be pickled.  This
+        functionality may be used to propagate structlog configurations to
+        subprocesses.
+
+        To ensure that ``CallsiteParameterAdder`` can be pickled, the handlers
+        should be defined as free functions, not as lambda functions.
+        """
+        pickle.dumps(CallsiteParameterAdder())
 
     @classmethod
     def make_processor(

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -498,9 +498,6 @@ class TestCallsiteParameterAdder:
         An instance of ``CallsiteParameterAdder`` can be pickled.  This
         functionality may be used to propagate structlog configurations to
         subprocesses.
-
-        To ensure that ``CallsiteParameterAdder`` can be pickled, the handlers
-        should be defined as free functions, not as lambda functions.
         """
         pickle.dumps(CallsiteParameterAdder())
 


### PR DESCRIPTION

# Summary

<!-- Please tell us what your pull request is about here. -->

Prior to this commit, the `CallsiteParameterAdder` object could not be pickled.  As a result, structlog configurations could not be propagated to subprocesses using `pickle.dumps(structlog.get_config())`.  This commit updates the handlers in `CallsiteParameterAdder._handlers` to be free functions, rather than lambda functions, so that all class members can be pickled.

Closes #600

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [n/a] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [n/a] Updated **documentation** for changed code.
    - [n/a] New functions/classes have to be added to `docs/api.rst` by hand.
    - [n/a] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
