### PR TITLE
structlog.testing.CapturingLogger now handles bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.LogfmtRenderer` now escapes backslashes and double quotes.
   [#594](https://github.com/hynek/structlog/pull/594)
 
+- `structlog.testing.CapturingLogger` now handles `bind`, `unbind` and `new` as expected by `BoundLogger` returning itself.
+  [#604](https://github.com/hynek/structlog/pull/604)
 
 
 ## [24.1.0](https://github.com/hynek/structlog/compare/23.3.0...24.1.0) - 2024-01-08

--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -164,6 +164,9 @@ class CapturingLogger:
     **Any** method name is supported.
 
     .. versionadded:: 20.2.0
+    .. versionchanged:: 23.2.0
+       Handle `BoundLogger` methods like `bind`, `new` or `unbind` now properly
+       returning itself.
     """
 
     calls: list[CapturedCall]
@@ -179,8 +182,12 @@ class CapturingLogger:
         Capture call to `calls`
         """
 
-        def log(*args: Any, **kw: Any) -> None:
+        def log(*args: Any, **kw: Any) -> Any:
             self.calls.append(CapturedCall(name, args, kw))
+            if name in ("bind", "new", "unbind"):
+                # these BoundLogger methods expect to return a "new" logger
+                return self
+            return None
 
         return log
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -155,18 +155,30 @@ class TestCapturingLogger:
 
     def test_captures(self):
         """
-        All calls to all names are captured.
+        All calls to all names are captured, BoundLogger methods can be used.
         """
         cl = CapturingLogger()
 
-        cl.info("hi", val=42)
-        cl.trololo("yolo", foo={"bar": "baz"})
+        assert cl.info("hi", val=42) is None
+        new_cl = cl.new(new=True)
+        bound_cl = new_cl.bind(bound=True)
+        assert bound_cl.trololo("yolo", foo={"bar": "baz"}) is None
+        unbound_cl = new_cl.unbind("bound", "new")
+        unbound_cl.error("Where are my vars?")
 
         assert [
             CapturedCall(method_name="info", args=("hi",), kwargs={"val": 42}),
+            CapturedCall(method_name="new", args=(), kwargs={"new": True}),
+            CapturedCall(method_name="bind", args=(), kwargs={"bound": True}),
             CapturedCall(
                 method_name="trololo",
                 args=("yolo",),
                 kwargs={"foo": {"bar": "baz"}},
+            ),
+            CapturedCall(
+                method_name="unbind", args=("bound", "new"), kwargs={}
+            ),
+            CapturedCall(
+                method_name="error", args=("Where are my vars?",), kwargs={}
             ),
         ] == cl.calls


### PR DESCRIPTION
# Summary

Using the `CapturingLogger` for a function that does `logger.bind` currently fails 


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
