### PR TITLE
optimize CallsiteParameterAdder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.LogfmtRenderer` now escapes backslashes and double quotes.
   [#594](https://github.com/hynek/structlog/pull/594)
 
-- `structlog.processors.CallsiteParameterAdder` has been optimized to be 30% faster.
+- `structlog.processors.CallsiteParameterAdder` has been optimized to be about 2x faster.
   [#606](https://github.com/hynek/structlog/pull/606)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.LogfmtRenderer` now escapes backslashes and double quotes.
   [#594](https://github.com/hynek/structlog/pull/594)
 
+- `structlog.processors.CallsiteParameterAdder` has been optimized to be 30% faster.
+  [#606](https://github.com/hynek/structlog/pull/606)
+
 
 
 ## [24.1.0](https://github.com/hynek/structlog/compare/23.3.0...24.1.0) - 2024-01-08

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import datetime
 import enum
-import inspect
 import json
 import logging
 import operator
@@ -20,6 +19,7 @@ import sys
 import threading
 import time
 
+from types import FrameType
 from typing import (
     Any,
     Callable,
@@ -724,42 +724,42 @@ class CallsiteParameter(enum.Enum):
     PROCESS_NAME = "process_name"
 
 
-def _get_callsite_pathname(module: str, frame_info: inspect.Traceback) -> Any:
-    return frame_info.filename
+def _get_callsite_pathname(module: str, frame: FrameType) -> Any:
+    return frame.f_code.co_filename
 
 
-def _get_callsite_filename(module: str, frame_info: inspect.Traceback) -> Any:
-    return os.path.basename(frame_info.filename)
+def _get_callsite_filename(module: str, frame: FrameType) -> Any:
+    return os.path.basename(frame.f_code.co_filename)
 
 
-def _get_callsite_module(module: str, frame_info: inspect.Traceback) -> Any:
-    return os.path.splitext(os.path.basename(frame_info.filename))[0]
+def _get_callsite_module(module: str, frame: FrameType) -> Any:
+    return os.path.splitext(os.path.basename(frame.f_code.co_filename))[0]
 
 
-def _get_callsite_func_name(module: str, frame_info: inspect.Traceback) -> Any:
-    return frame_info.function
+def _get_callsite_func_name(module: str, frame: FrameType) -> Any:
+    return frame.f_code.co_name
 
 
-def _get_callsite_lineno(module: str, frame_info: inspect.Traceback) -> Any:
-    return frame_info.lineno
+def _get_callsite_lineno(module: str, frame: FrameType) -> Any:
+    return frame.f_lineno
 
 
-def _get_callsite_thread(module: str, frame_info: inspect.Traceback) -> Any:
+def _get_callsite_thread(module: str, frame: FrameType) -> Any:
     return threading.get_ident()
 
 
 def _get_callsite_thread_name(
-    module: str, frame_info: inspect.Traceback
+    module: str, frame: FrameType
 ) -> Any:
     return threading.current_thread().name
 
 
-def _get_callsite_process(module: str, frame_info: inspect.Traceback) -> Any:
+def _get_callsite_process(module: str, frame: FrameType) -> Any:
     return os.getpid()
 
 
 def _get_callsite_process_name(
-    module: str, frame_info: inspect.Traceback
+    module: str, frame: FrameType
 ) -> Any:
     return get_processname()
 
@@ -805,7 +805,7 @@ class CallsiteParameterAdder:
     """
 
     _handlers: ClassVar[
-        dict[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
+        dict[CallsiteParameter, Callable[[str, FrameType], Any]]
     ] = {
         CallsiteParameter.PATHNAME: _get_callsite_pathname,
         CallsiteParameter.FILENAME: _get_callsite_filename,
@@ -879,9 +879,8 @@ class CallsiteParameterAdder:
             frame, module = _find_first_app_frame_and_name(
                 additional_ignores=self._additional_ignores
             )
-            frame_info = inspect.getframeinfo(frame, context=0)
             for parameter, handler in self._active_handlers:
-                event_dict[parameter.value] = handler(module, frame_info)
+                event_dict[parameter.value] = handler(module, frame)
         return event_dict
 
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -879,7 +879,7 @@ class CallsiteParameterAdder:
             frame, module = _find_first_app_frame_and_name(
                 additional_ignores=self._additional_ignores
             )
-            frame_info = inspect.getframeinfo(frame)
+            frame_info = inspect.getframeinfo(frame, context=0)
             for parameter, handler in self._active_handlers:
                 event_dict[parameter.value] = handler(module, frame_info)
         return event_dict

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -748,9 +748,7 @@ def _get_callsite_thread(module: str, frame: FrameType) -> Any:
     return threading.get_ident()
 
 
-def _get_callsite_thread_name(
-    module: str, frame: FrameType
-) -> Any:
+def _get_callsite_thread_name(module: str, frame: FrameType) -> Any:
     return threading.current_thread().name
 
 
@@ -758,9 +756,7 @@ def _get_callsite_process(module: str, frame: FrameType) -> Any:
     return os.getpid()
 
 
-def _get_callsite_process_name(
-    module: str, frame: FrameType
-) -> Any:
+def _get_callsite_process_name(module: str, frame: FrameType) -> Any:
     return get_processname()
 
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -845,7 +845,7 @@ class CallsiteParameterAdder:
         # module should not be logging using structlog.
         self._additional_ignores = ["logging", *additional_ignores]
         self._active_handlers: list[
-            tuple[CallsiteParameter, Callable[[str, inspect.Traceback], Any]]
+            tuple[CallsiteParameter, Callable[[str, FrameType], Any]]
         ] = []
         self._record_mappings: list[CallsiteParameterAdder._RecordMapping] = []
         for parameter in parameters:


### PR DESCRIPTION
# Summary

CallsiteParameterAdder is slower than logging.Logger.findCaller() because findCaller() doesn't use inspect at all.
~This commit doesn't stop using inspect.getframeinfo(), but skips heavy code_context calculation.~
This commit changes CallsiteParameterAdder to use frame object directly like findCaller().

**Bench:**

```py
import structlog
import timeit
import os

null = open(os.devnull, "w", encoding="utf-8")

structlog.configure(
    processors=[
        structlog.processors.CallsiteParameterAdder([
            structlog.processors.CallsiteParameter.FILENAME,
            structlog.processors.CallsiteParameter.LINENO,
            ]),
        structlog.processors.JSONRenderer()
    ],
    logger_factory=structlog.PrintLoggerFactory(null),
    cache_logger_on_first_use=False
)
log = structlog.get_logger()

N = 100_000
x = timeit.timeit(lambda: log.info("hello"), number=N)
print(f"{x*1000_000/N}us")
```

**Result:**
```
before:
18.325596249997034us

getframeinfo(frame, context=0):
12.43612457998097us

use frame directly:
6.971802920015762us
```

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
