### PR TITLE
add some note about logging configuration

### DIFF
--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -143,7 +143,9 @@ The most straight-forward option is to configure standard library `logging` clos
 
 Since these are usually log entries from third parties that don't take advantage of *structlog*'s features, this is surprisingly often a perfectly adequate approach.
 
-For instance, if you log JSON in production, configure `logging` to use [*python-json-logger*] to make it print JSON too, and then tweak the configuration to match their outputs.
+For instance, if you log JSON in production, configure `logging` to use [*python-json-logger*] to make it print JSON too, and then tweak the configuration to match their outputs. You can also use {class}`~structlog.stdlib.ProcessorFormatter` as a formatter for `logging` to get the same output for both *structlog* and `logging` log entries. (see [below](processor-formatter) for an example).
+
+If you want to use same file (e.g. `sys.stdout` or `sys.stderr`) for both *structlog* and `logging` log entries, you must use {class}`~structlog.WriterLogger` instead of {class}`~structlog.PrintLogger`. This is because {class}`~structlog.PrintLogger` uses `print(log, file=file, flush=True)` to write log and `print` writes `log` and `"\n"` to the file separatedly. This can cause interleaving of log entries from *structlog* and `logging` loggers. {class}`~structlog.WriterLogger` writes log entries atomically to the file (e.g. `file.write(log+"\n")`).
 
 
 ### Rendering Within *structlog*

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -145,7 +145,11 @@ Since these are usually log entries from third parties that don't take advantage
 
 For instance, if you log JSON in production, configure `logging` to use [*python-json-logger*] to make it print JSON too, and then tweak the configuration to match their outputs. You can also use {class}`~structlog.stdlib.ProcessorFormatter` as a formatter for `logging` to get the same output for both *structlog* and `logging` log entries. (see [below](processor-formatter) for an example).
 
-If you want to use same file (e.g. `sys.stdout` or `sys.stderr`) for both *structlog* and `logging` log entries, you must use {class}`~structlog.WriterLogger` instead of {class}`~structlog.PrintLogger`. This is because {class}`~structlog.PrintLogger` uses `print(log, file=file, flush=True)` to write log and `print` writes `log` and `"\n"` to the file separatedly. This can cause interleaving of log entries from *structlog* and `logging` loggers. {class}`~structlog.WriterLogger` writes log entries atomically to the file (e.g. `file.write(log+"\n")`).
+:::{note}
+If you want to use same file (e.g. `sys.stdout` or `sys.stderr`) for both *structlog* and `logging.StreamHandler` output, you must use {class}`!~structlog._output.WriterLogger` instead of {class}`~structlog._output.PrintLogger`.
+
+This is because {class}`~structlog.PrintLogger` uses `print(log, file=file, flush=True)` to write log, and `print` writes the `log` message and a newline ("\n") to the stream separately. This can cause interleaving of log entries from *structlog* and `logging` loggers. {class}`!~structlog._output.WriterLogger` writes log entries atomically to the file (e.g. `file.write(log+"\n")`).
+:::
 
 
 ### Rendering Within *structlog*

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -143,12 +143,15 @@ The most straight-forward option is to configure standard library `logging` clos
 
 Since these are usually log entries from third parties that don't take advantage of *structlog*'s features, this is surprisingly often a perfectly adequate approach.
 
-For instance, if you log JSON in production, configure `logging` to use [*python-json-logger*] to make it print JSON too, and then tweak the configuration to match their outputs. You can also use {class}`~structlog.stdlib.ProcessorFormatter` as a formatter for `logging` to get the same output for both *structlog* and `logging` log entries. (see [below](processor-formatter) for an example).
+For instance, if you log JSON in production, configure `logging` to use [*python-json-logger*] to make it print JSON too, and then tweak the configuration to match their outputs.
+You can also use {class}`~structlog.stdlib.ProcessorFormatter` as a formatter for `logging` to get the same output for both *structlog* and `logging` log entries -- see [below](processor-formatter) for an example.
 
 :::{note}
-If you want to use same file (e.g. `sys.stdout` or `sys.stderr`) for both *structlog* and `logging.StreamHandler` output, you must use {class}`!~structlog._output.WriterLogger` instead of {class}`~structlog._output.PrintLogger`.
+If you want to use same file (for example, `sys.stdout` or `sys.stderr`) for both *structlog* and `logging.StreamHandler` output, you must use {class}`~structlog.WriteLogger` instead of {class}`~structlog.PrintLogger`.
 
-This is because {class}`~structlog.PrintLogger` uses `print(log, file=file, flush=True)` to write log, and `print` writes the `log` message and a newline ("\n") to the stream separately. This can cause interleaving of log entries from *structlog* and `logging` loggers. {class}`!~structlog._output.WriterLogger` writes log entries atomically to the file (e.g. `file.write(log+"\n")`).
+This is because {class}`~structlog.PrintLogger` uses `print(log, file=file, flush=True)` to write log, and `print` writes the `log` message and a newline ("\n") to the stream separately.
+This can cause interleaving of log entries from *structlog* and `logging` loggers.
+{class}`~structlog.WriteLogger` writes log entries atomically to the file (for example, `file.write(log+"\n")`).
 :::
 
 


### PR DESCRIPTION
# Summary

I read [Standard Library](https://www.structlog.org/en/stable/standard-library.html) document and tested some configurations. I see "Don't Integrate" approach is faster than integrate approaches.

So I want to improve the "Don't Integrate" section a bit:

* Mention about ProcessorFormatter can be used for logging formatter. It is easier than python-json-logger when I want to use similar format between structlog and logging.
* Note that PrintLogger is not safe when both of structlog and logging shares same output file.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
