### PR TITLE
Fix reference to undefined var `logger` in "Getting Started" example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,7 +120,7 @@ Let's have a look at a better approach:
 
 ```python
 def view(request):
-    log = logger.bind(
+    log = log.bind(
         user_agent=request.get("HTTP_USER_AGENT", "UNKNOWN"),
         peer_ip=request.client_addr,
     )


### PR DESCRIPTION

# Summary

<!-- Please tell us what your pull request is about here. -->
Just changing the name of one variable in one docs example.

# Motivation 

While following along with the "Getting Started" guide for the first time, I got sidetracked for several minutes by this `logger`.

None of the example snippets earlier in the file assigned to a variable named `logger` (but they frequently assigned the result of `structlog.get_logger()` to a variable named `log`).

I spent a bit poking around in the API reference to try and figure out which types define a `.bind()` method and whether they completely overlap with the types returned by `structlog.get_logger()`.  

Eventually I decided the specific variable name probably wasn't a super considered choice and I was overthinking things.

Maybe this change could save someone time in the future.

# Further Discussion

It'd be nice (maybe not super valuable, but nice) if a single naming convention were used throughout the docs.  I was considering making this a "unify all the names" PR, but figured that might be a waste of time without getting style input from @hynek first.

I found ~71 uses of `log` and ~41 uses of `logger` in markdown files (approximately; used a rough regex to try and find relevant cases).  *Is* there a considered reason to use one or the other, or has it been pretty arbitrary? 

Some theories I had, but found counterexamples for:

1. maybe you're trying to avoid assigning to a variable the result of evaluating an expression containing that variable
2. maybe one of `log`/`logger` is for the result of `structlog.get_logger()` and the other is for the result of a `.bind()`


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
