### PR TITLE
Improve dict traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,23 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.2.0...HEAD)
 
+### Added
+
+- Restore feature parity between `structlog.traceback.ExceptionDictTransformer` and Rich's traceback extractor:
+
+  - When displaying locals, use Rich for formatting if it is available.
+  - When displaying locals, call `repr()` on strings, too (improves handling of `SecretStr` implementations).
+  - Add `locals_max_length` config option
+  - Add `locals_hide_sunder` config option
+  - Add `locals_hide_dunder` config option
+  - Add `suppress` config option
+
+  [!627](https://github.com/hynek/structlog/pull/627)
+
 ### Changed
 
 - `structlog.testing.capture_logs()` now maps the `exception` log level to `error` (as it's elsewhere).
   [#628](https://github.com/hynek/structlog/pull/628)
-
 
 ## [24.2.0](https://github.com/hynek/structlog/compare/24.1.0...24.2.0) - 2024-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   - Add `locals_hide_dunder` config option
   - Add `suppress` config option
 
-  [!627](https://github.com/hynek/structlog/pull/627)
+  [#627](https://github.com/hynek/structlog/pull/627)
 
 ### Changed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -197,7 +197,7 @@ API Reference
          ...     1 / 0
          ... except ZeroDivisionError:
          ...     log.exception("Cannot compute!")
-         {"event": "Cannot compute!", "exception": [{"exc_type": "ZeroDivisionError", "exc_value": "division by zero", "syntax_error": null, "is_cause": false, "frames": [{"filename": "<doctest default[3]>", "lineno": 2, "name": "<module>", "line": "", "locals": {..., "var": "spam"}}]}]}
+         {"event": "Cannot compute!", "exception": [{"exc_type": "ZeroDivisionError", "exc_value": "division by zero", "syntax_error": null, "is_cause": false, "frames": [{"filename": "<doctest default[3]>", "lineno": 2, "name": "<module>", "locals": {..., "var": "'spam'"}}]}]}
 
 .. autoclass:: KeyValueRenderer
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ nitpick_ignore = [
     ("py:class", "WrappedLogger"),
     ("py:class", "structlog.threadlocal.TLLogger"),
     ("py:class", "structlog.typing.EventDict"),
+    ("py:class", "ModuleType"),
 ]
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -6,7 +6,7 @@
 """
 Extract a structured traceback from an exception.
 
-`Contributed by Will McGugan
+Based on `work by Will McGugan
 <https://github.com/hynek/structlog/pull/407#issuecomment-1150926246>`_ from
 `rich.traceback
 <https://github.com/Textualize/rich/blob/972dedff/rich/traceback.py>`_.

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -128,6 +128,11 @@ def to_repr(
 
     Returns:
         The string representation of *obj*.
+
+    .. versionchanged:: 24.3.0
+       Added *max_length* argument.  Use :program:`rich` to render locals if it
+       is available.  Call :func:`repr()` on strings in fallback
+       implementation.
     """
     if rich is not None:
         # Let rich render the repr if it is available.
@@ -201,6 +206,9 @@ def extract(
         A Trace instance with structured information about all exceptions.
 
     .. versionadded:: 22.1.0
+    .. versionchanged:: 24.3.0
+       Added *locals_max_length*, *locals_hide_sunder* and
+       *locals_hide_dunder* arguments.
     """
 
     stacks: list[Stack] = []
@@ -337,6 +345,9 @@ class ExceptionDictTransformer:
     .. seealso::
         :doc:`exceptions` for a broader explanation of *structlog*'s exception
         features.
+    .. versionchanged:: 24.3.0
+       Added *locals_max_length*, *locals_hide_sunder*, *locals_hide_dunder*
+       and *suppress* arguments.
     """
 
     def __init__(

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -41,7 +41,7 @@ def test_save_str(data: Any, expected: str):
     """
     "safe_str()" returns the str repr of an object.
     """
-    assert tracebacks.safe_str(data) == expected
+    assert expected == tracebacks.safe_str(data)
 
 
 def test_safe_str_error():
@@ -56,7 +56,7 @@ def test_safe_str_error():
     with pytest.raises(ValueError, match="BAAM!"):
         str(Baam())
 
-    assert tracebacks.safe_str(Baam()) == "<str-error 'BAAM!'>"
+    assert "<str-error 'BAAM!'>" == tracebacks.safe_str(Baam())
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_to_repr(data: Any, max_len: int | None, expected: str) -> None:
     """
     "to_repr()" returns the repr of an object, trimmed to max_len.
     """
-    assert tracebacks.to_repr(data, max_string=max_len) == expected
+    assert expected == tracebacks.to_repr(data, max_string=max_len)
 
 
 @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ def test_to_repr_rich(
         pytest.skip(reason="rich not installed")
 
     monkeypatch.setattr(tracebacks, "rich", rich)
-    assert tracebacks.to_repr(data, max_string=max_len) == expected
+    assert expected == tracebacks.to_repr(data, max_string=max_len)
 
 
 def test_to_repr_error() -> None:
@@ -121,7 +121,7 @@ def test_to_repr_error() -> None:
     with pytest.raises(ValueError, match="BAAM!"):
         repr(Baam())
 
-    assert tracebacks.to_repr(Baam()) == "<repr-error 'BAAM!'>"
+    assert "<repr-error 'BAAM!'>" == tracebacks.to_repr(Baam())
 
 
 def test_simple_exception():
@@ -134,7 +134,7 @@ def test_simple_exception():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -149,7 +149,7 @@ def test_simple_exception():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_raise_hide_cause():
@@ -166,7 +166,7 @@ def test_raise_hide_cause():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -181,7 +181,7 @@ def test_raise_hide_cause():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_raise_with_cause():
@@ -199,7 +199,7 @@ def test_raise_with_cause():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -228,7 +228,7 @@ def test_raise_with_cause():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_raise_with_cause_no_tb():
@@ -241,7 +241,7 @@ def test_raise_with_cause_no_tb():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -256,7 +256,7 @@ def test_raise_with_cause_no_tb():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_raise_nested():
@@ -274,7 +274,7 @@ def test_raise_nested():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -303,7 +303,7 @@ def test_raise_nested():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_raise_no_msg():
@@ -317,7 +317,7 @@ def test_raise_no_msg():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="RuntimeError",
             exc_value="",
@@ -332,7 +332,7 @@ def test_raise_no_msg():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_syntax_error():
@@ -346,7 +346,7 @@ def test_syntax_error():
     except SyntaxError as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="SyntaxError",
             exc_value="invalid syntax (<string>, line 1)",
@@ -366,7 +366,7 @@ def test_syntax_error():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_filename_with_bracket():
@@ -379,7 +379,7 @@ def test_filename_with_bracket():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -400,7 +400,7 @@ def test_filename_with_bracket():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_filename_not_a_file():
@@ -413,7 +413,7 @@ def test_filename_not_a_file():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -434,7 +434,7 @@ def test_filename_not_a_file():
                 ),
             ],
         ),
-    ]
+    ] == trace.stacks
 
 
 def test_show_locals():
@@ -483,7 +483,7 @@ def test_recursive():
     frames = trace.stacks[0].frames
     trace.stacks[0].frames = []
 
-    assert trace.stacks == [
+    assert [
         tracebacks.Stack(
             exc_type="RecursionError",
             exc_value="maximum recursion depth exceeded",
@@ -491,7 +491,7 @@ def test_recursive():
             is_cause=False,
             frames=[],
         ),
-    ]
+    ] == trace.stacks
     assert (
         len(frames) > sys.getrecursionlimit() - 50
     )  # Buffer for frames from pytest
@@ -536,7 +536,7 @@ def test_json_traceback():
         format_json = tracebacks.ExceptionDictTransformer(show_locals=False)
         result = format_json((type(e), e, e.__traceback__))
 
-    assert result == [
+    assert [
         {
             "exc_type": "ZeroDivisionError",
             "exc_value": "division by zero",
@@ -550,7 +550,7 @@ def test_json_traceback():
             "is_cause": False,
             "syntax_error": None,
         },
-    ]
+    ] == result
 
 
 def test_json_traceback_locals_max_string():
@@ -565,7 +565,7 @@ def test_json_traceback_locals_max_string():
         result = tracebacks.ExceptionDictTransformer(locals_max_string=4)(
             (type(e), e, e.__traceback__)
         )
-    assert result == [
+    assert [
         {
             "exc_type": "ZeroDivisionError",
             "exc_value": "division by zero",
@@ -584,7 +584,7 @@ def test_json_traceback_locals_max_string():
             "is_cause": False,
             "syntax_error": None,
         },
-    ]
+    ] == result
 
 
 @pytest.mark.parametrize(
@@ -699,7 +699,7 @@ def test_json_tracebacks_skip_sunder_dunder(
             locals_hide_dunder=hide_dunder,
         )
         result = format_json((type(e), e, e.__traceback__))
-        assert set(result[0]["frames"][1]["locals"]) == expected
+        assert expected == set(result[0]["frames"][1]["locals"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -101,7 +101,7 @@ def test_to_repr_rich(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    "to_repr()" uses Rich to get a nice repl if it is installed and if
+    "to_repr()" uses Rich to get a nice repr if it is installed and if
     "use_rich" is True.
     """
     try:

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -80,25 +80,29 @@ def test_to_repr(data: Any, max_len: int | None, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("data", "max_len", "expected"),
+    ("use_rich", "data", "max_len", "expected"),
     [
-        (3, None, "3"),
-        ("spam", None, "'spam'"),
-        (b"spam", None, "b'spam'"),
-        ("bacon", 3, "'bac'+2"),
-        ("bacon", 5, "'bacon'"),
-        (SecretStr("password"), None, "*******"),
-        (["spam", "eggs", "bacon"], 4, "['spam', 'eggs', 'baco'+1]"),
+        (True, 3, None, "3"),
+        (True, "spam", None, "'spam'"),
+        (True, b"spam", None, "b'spam'"),
+        (True, "bacon", 3, "'bac'+2"),
+        (True, "bacon", 5, "'bacon'"),
+        (True, SecretStr("password"), None, "*******"),
+        (True, ["spam", "eggs", "bacon"], 4, "['spam', 'eggs', 'baco'+1]"),
+        (False, "bacon", 3, "'bac'+2"),
+        (False, ["spam", "eggs", "bacon"], 4, '"[\'sp"+21'),
     ],
 )
 def test_to_repr_rich(
+    use_rich: bool,
     data: Any,
     max_len: int | None,
     expected: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    "to_repr()" uses Rich to get a nice repl if it is installed.
+    "to_repr()" uses Rich to get a nice repl if it is installed and if
+    "use_rich" is True.
     """
     try:
         import rich
@@ -106,7 +110,9 @@ def test_to_repr_rich(
         pytest.skip(reason="rich not installed")
 
     monkeypatch.setattr(tracebacks, "rich", rich)
-    assert expected == tracebacks.to_repr(data, max_string=max_len)
+    assert expected == tracebacks.to_repr(
+        data, max_string=max_len, use_rich=use_rich
+    )
 
 
 def test_to_repr_error() -> None:

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -41,7 +41,7 @@ def test_save_str(data: Any, expected: str):
     """
     "safe_str()" returns the str repr of an object.
     """
-    assert expected == tracebacks.safe_str(data)
+    assert tracebacks.safe_str(data) == expected
 
 
 def test_safe_str_error():
@@ -56,7 +56,7 @@ def test_safe_str_error():
     with pytest.raises(ValueError, match="BAAM!"):
         str(Baam())
 
-    assert "<str-error 'BAAM!'>" == tracebacks.safe_str(Baam())
+    assert tracebacks.safe_str(Baam()) == "<str-error 'BAAM!'>"
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ def test_to_repr(data: Any, max_len: int | None, expected: str) -> None:
     """
     "to_repr()" returns the repr of an object, trimmed to max_len.
     """
-    assert expected == tracebacks.to_repr(data, max_string=max_len)
+    assert tracebacks.to_repr(data, max_string=max_len) == expected
 
 
 @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ def test_to_repr_rich(
         pytest.skip(reason="rich not installed")
 
     monkeypatch.setattr(tracebacks, "rich", rich)
-    assert expected == tracebacks.to_repr(data, max_string=max_len)
+    assert tracebacks.to_repr(data, max_string=max_len) == expected
 
 
 def test_to_repr_error() -> None:
@@ -121,7 +121,7 @@ def test_to_repr_error() -> None:
     with pytest.raises(ValueError, match="BAAM!"):
         repr(Baam())
 
-    assert "<repr-error 'BAAM!'>" == tracebacks.to_repr(Baam())
+    assert tracebacks.to_repr(Baam()) == "<repr-error 'BAAM!'>"
 
 
 def test_simple_exception():
@@ -134,7 +134,7 @@ def test_simple_exception():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -145,12 +145,11 @@ def test_simple_exception():
                     filename=__file__,
                     lineno=lineno,
                     name="test_simple_exception",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_raise_hide_cause():
@@ -167,7 +166,7 @@ def test_raise_hide_cause():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -178,12 +177,11 @@ def test_raise_hide_cause():
                     filename=__file__,
                     lineno=lineno,
                     name="test_raise_hide_cause",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_raise_with_cause():
@@ -201,7 +199,7 @@ def test_raise_with_cause():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -212,7 +210,6 @@ def test_raise_with_cause():
                     filename=__file__,
                     lineno=lineno_2,
                     name="test_raise_with_cause",
-                    line="",
                     locals=None,
                 ),
             ],
@@ -227,12 +224,11 @@ def test_raise_with_cause():
                     filename=__file__,
                     lineno=lineno_1,
                     name="test_raise_with_cause",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_raise_with_cause_no_tb():
@@ -245,7 +241,7 @@ def test_raise_with_cause_no_tb():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -256,12 +252,11 @@ def test_raise_with_cause_no_tb():
                     filename=__file__,
                     lineno=lineno,
                     name="test_raise_with_cause_no_tb",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_raise_nested():
@@ -279,7 +274,7 @@ def test_raise_nested():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ValueError",
             exc_value="onoes",
@@ -290,7 +285,6 @@ def test_raise_nested():
                     filename=__file__,
                     lineno=lineno_2,
                     name="test_raise_nested",
-                    line="",
                     locals=None,
                 ),
             ],
@@ -305,12 +299,11 @@ def test_raise_nested():
                     filename=__file__,
                     lineno=lineno_1,
                     name="test_raise_nested",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_raise_no_msg():
@@ -324,7 +317,7 @@ def test_raise_no_msg():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="RuntimeError",
             exc_value="",
@@ -335,12 +328,11 @@ def test_raise_no_msg():
                     filename=__file__,
                     lineno=lineno,
                     name="test_raise_no_msg",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_syntax_error():
@@ -354,7 +346,7 @@ def test_syntax_error():
     except SyntaxError as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="SyntaxError",
             exc_value="invalid syntax (<string>, line 1)",
@@ -371,12 +363,10 @@ def test_syntax_error():
                     filename=__file__,
                     lineno=lineno,
                     name="test_syntax_error",
-                    line="",
-                    locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_filename_with_bracket():
@@ -389,7 +379,7 @@ def test_filename_with_bracket():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -400,19 +390,17 @@ def test_filename_with_bracket():
                     filename=__file__,
                     lineno=lineno,
                     name="test_filename_with_bracket",
-                    line="",
                     locals=None,
                 ),
                 tracebacks.Frame(
                     filename="<string>",
                     lineno=1,
                     name="<module>",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_filename_not_a_file():
@@ -425,7 +413,7 @@ def test_filename_not_a_file():
     except Exception as e:
         trace = tracebacks.extract(type(e), e, e.__traceback__)
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="ZeroDivisionError",
             exc_value="division by zero",
@@ -436,19 +424,17 @@ def test_filename_not_a_file():
                     filename=__file__,
                     lineno=lineno,
                     name="test_filename_not_a_file",
-                    line="",
                     locals=None,
                 ),
                 tracebacks.Frame(
                     filename=str(Path.cwd().joinpath("string")),
                     lineno=1,
                     name="<module>",
-                    line="",
                     locals=None,
                 ),
             ],
         ),
-    ] == trace.stacks
+    ]
 
 
 def test_show_locals():
@@ -497,7 +483,7 @@ def test_recursive():
     frames = trace.stacks[0].frames
     trace.stacks[0].frames = []
 
-    assert [
+    assert trace.stacks == [
         tracebacks.Stack(
             exc_type="RecursionError",
             exc_value="maximum recursion depth exceeded",
@@ -505,7 +491,7 @@ def test_recursive():
             is_cause=False,
             frames=[],
         ),
-    ] == trace.stacks
+    ]
     assert (
         len(frames) > sys.getrecursionlimit() - 50
     )  # Buffer for frames from pytest
@@ -550,7 +536,7 @@ def test_json_traceback():
         format_json = tracebacks.ExceptionDictTransformer(show_locals=False)
         result = format_json((type(e), e, e.__traceback__))
 
-    assert [
+    assert result == [
         {
             "exc_type": "ZeroDivisionError",
             "exc_value": "division by zero",
@@ -564,7 +550,7 @@ def test_json_traceback():
             "is_cause": False,
             "syntax_error": None,
         },
-    ] == result
+    ]
 
 
 def test_json_traceback_locals_max_string():
@@ -579,7 +565,7 @@ def test_json_traceback_locals_max_string():
         result = tracebacks.ExceptionDictTransformer(locals_max_string=4)(
             (type(e), e, e.__traceback__)
         )
-    assert [
+    assert result == [
         {
             "exc_type": "ZeroDivisionError",
             "exc_value": "division by zero",
@@ -598,7 +584,7 @@ def test_json_traceback_locals_max_string():
             "is_cause": False,
             "syntax_error": None,
         },
-    ] == result
+    ]
 
 
 @pytest.mark.parametrize(
@@ -719,16 +705,22 @@ def test_json_tracebacks_skip_sunder_dunder(
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {"locals_max_length": -1},
         {"locals_max_string": -1},
         {"max_frames": -1},
         {"max_frames": 0},
         {"max_frames": 1},
+        {"suppress": (json,)},
     ],
 )
-def test_json_traceback_value_error(kwargs):
+def test_json_traceback_value_error(
+    kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """
     Wrong arguments to ExceptionDictTransformer raise a ValueError that
     contains the name of the argument..
     """
+    if "suppress" in kwargs:
+        monkeypatch.setattr(kwargs["suppress"][0], "__file__", None)
     with pytest.raises(ValueError, match=next(iter(kwargs.keys()))):
         tracebacks.ExceptionDictTransformer(**kwargs)


### PR DESCRIPTION
# Summary

Restore feature parity between Rich's traceback extractor:

- When displaying locals, call `repr()` on strings, too.
- Add `locals_max_length` config option
- Add `locals_hide_sunder` config option
- Add `locals_hide_dunder` config option
- Add `suppress` config option


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
