### PR TITLE
Map method name in capture_logs as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Changed
 
-- capture_logs now map exception log level to error
+- `structlog.testing.capture_logs()` now maps the `exception` log level to `error` (as it's elsewhere).
+  [#628](https://github.com/hynek/structlog/pull/628)
 
 
 ## [24.2.0](https://github.com/hynek/structlog/compare/24.1.0...24.2.0) - 2024-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 <!-- changelog follows -->
 
+
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.2.0...HEAD)
 
+### Changed
+
 - capture_logs now map exception log level to error
+
 
 ## [24.2.0](https://github.com/hynek/structlog/compare/24.1.0...24.2.0) - 2024-05-27
 
@@ -29,6 +33,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.CallsiteParameterAdder` now also works with `structlog.stdlib.BoundLogger`'s non-standard async methods (`ainfo()`, and so forth)
   [#618](https://github.com/hynek/structlog/pull/618)
 
+
 ### Changed
 
 - `structlog.processors.LogfmtRenderer` now escapes newlines.
@@ -40,10 +45,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.CallsiteParameterAdder` has been optimized to be about 2x faster.
   [#606](https://github.com/hynek/structlog/pull/606)
 
+
 ### Fixed
 
 - `structlog.stdlib.render_to_log_kwargs` now correctly passes stacklevel as a kwarg to stdlib logging.
   [#619](https://github.com/hynek/structlog/pull/620)
+
+
 
 ## [24.1.0](https://github.com/hynek/structlog/compare/23.3.0...24.1.0) - 2024-01-08
 
@@ -59,6 +67,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Don't ignore the `width` argument of `RichTracebackFormatter`.
   [#587](https://github.com/hynek/structlog/issues/587)
 
+
 ## [23.3.0](https://github.com/hynek/structlog/compare/23.2.0...23.3.0) - 2023-12-29
 
 ### Added
@@ -73,10 +82,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Async log methods (those starting with an `a`) now also support the collection of callsite information using `structlog.processors.CallsiteParameterAdder`.
   [#565](https://github.com/hynek/structlog/issues/565)
 
+
 ### Changed
 
 - `structlog.stdlib.recreate_defaults()` now also adds `structlog.stdlib.add_logger_name` to the processors.
   Check out the [updated screenshot](https://raw.githubusercontent.com/hynek/structlog/main/docs/_static/console_renderer.png)!
+
 
 ### Fixed
 
@@ -92,11 +103,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#571](https://github.com/hynek/structlog/issues/571)
   [#572](https://github.com/hynek/structlog/issues/572)
 
+
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 
 ### Removed
 
 - Support for Python 3.7.
+
 
 ### Added
 
@@ -106,18 +119,20 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.MaybeTimeStamper` that only adds a timestamp if there isn't one already.
   [#81](https://github.com/hynek/structlog/issues/81)
 
-- `structlog.dev.ConsoleRenderer` now supports renamed timestamp keys using the _timestamp_key_ parameter.
+- `structlog.dev.ConsoleRenderer` now supports renamed timestamp keys using the *timestamp_key* parameter.
   [#541](https://github.com/hynek/structlog/issues/541)
 
 - `structlog.dev.RichTracebackFormatter` that allows to configure the traceback formatting.
   [#542](https://github.com/hynek/structlog/issues/542)
 
+
 ### Fixed
 
-- `FilteringBoundLogger.exception()` and `FilteringBoundLogger.aexception()` now support positional argument formatting like the rest of the methods.
+- `FilteringBoundLogger.exception()` and  `FilteringBoundLogger.aexception()` now support positional argument formatting like the rest of the methods.
   [#531](https://github.com/hynek/structlog/issues/531)
 - `structlog.processors.format_exc_info()` and `structlog.dev.ConsoleRenderer` do not crash anymore when told to format a non-existent exception.
   [#533](https://github.com/hynek/structlog/issues/533)
+
 
 ## [23.1.0](https://github.com/hynek/structlog/compare/22.3.0...23.1.0) - 2023-04-06
 
@@ -134,36 +149,41 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   This disables all heuristics whether it makes sense to use colors and overrides `FORCE_COLOR`.
   [#504](https://github.com/hynek/structlog/issues/504)
 
+
 ### Fixed
 
 - ConsoleRenderer now reuses the `_figure_out_exc_info` to process the `exc_info` argument like `ExceptionRenderer` does.
-  This prevents crashes if the actual Exception is passed for the _exc_info_ argument instead of a tuple or `True`.
+  This prevents crashes if the actual Exception is passed for the *exc_info* argument instead of a tuple or `True`.
   [#482](https://github.com/hynek/structlog/issues/482)
 
 - `FilteringBoundLogger.aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio executor (where original exception info is no longer available).
   [#488](https://github.com/hynek/structlog/issues/488)
+
 
 ## [22.3.0](https://github.com/hynek/structlog/compare/22.2.0...22.3.0) - 2022-11-24
 
 ### Changed
 
 - String interpolation in `FilteringBoundLogger` (used by default) is now only attempted if positional arguments are passed.
-  This prevents crashes if something different than a string is passed for the _event_ argument.
+  This prevents crashes if something different than a string is passed for the *event* argument.
   [#475](https://github.com/hynek/structlog/pull/475)
+
 
 ### Fixed
 
 - String interpolation doesn't cause crashes in filtered log call anymore.
   [#478](https://github.com/hynek/structlog/pull/478)
 
+
 ## [22.2.0](https://github.com/hynek/structlog/compare/22.1.0...22.2.0) - 2022-11-19
 
 ### Deprecated
 
-- Accessing package metadata as attributes on the _structlog_ module is deprecated (for example, `structlog.__version__`).
-  Please use [`importlib.metadata`](https://docs.python.org/3.10/library/importlib.metadata.html) instead (for Python 3.7: the [_importlib-metadata_](https://pypi.org/project/importlib-metadata/) PyPI package).
+- Accessing package metadata as attributes on the *structlog* module is deprecated (for example, `structlog.__version__`).
+  Please use [`importlib.metadata`](https://docs.python.org/3.10/library/importlib.metadata.html) instead (for Python 3.7: the [*importlib-metadata*](https://pypi.org/project/importlib-metadata/) PyPI package).
 - The `structlog.types` module is now deprecated in favor of the `structlog.typing` module.
   It seems like the Python typing community is settling on this name.
+
 
 ### Added
 
@@ -176,23 +196,26 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
   [#454](https://github.com/hynek/structlog/pull/454)
 
-- `FilteringBoundLogger` now also has support for _asyncio_-based logging.
+- `FilteringBoundLogger` now also has support for *asyncio*-based logging.
   Instead of a wrapper class like `structlog.stdlib.AsyncBoundLogger`, async equivalents have been added for all logging methods.
   So instead of `log.info("hello")` you can also write `await log.ainfo("hello")` in async functions and methods.
 
   This seems like the better approach and if it's liked by the community, `structlog.stdlib.BoundLogger` will get those methods too.
   [#457](https://github.com/hynek/structlog/pull/457)
 
+
 ### Changed
 
 - The documentation has been **heavily** overhauled.
   Have a look if you haven't lately!
   Especially the graphs in the [standard library chapter](https://www.structlog.org/en/latest/standard-library.html) have proven valuable to many.
-- The build backend has been switched to [_Hatch_](https://hatch.pypa.io/).
+- The build backend has been switched to [*Hatch*](https://hatch.pypa.io/).
+
 
 ### Fixed
 
 - The timestamps in the default configuration now use the correct separator (`:`) for seconds.
+
 
 ## [22.1.0](https://github.com/hynek/structlog/compare/21.5.0...22.1.0) - 2022-07-20
 
@@ -200,6 +223,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - Python 3.6 is not supported anymore.
 - Pickling is now only possible with protocol version 3 and newer.
+
 
 ### Deprecated
 
@@ -212,9 +236,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   Currently there are no concrete plans to remove the module, but no patches against it will be accepted from now on.
   [#409](https://github.com/hynek/structlog/pull/409)
 
+
 ### Added
 
-- `structlog.processors.StackInfoRenderer` now has an _additional_ignores_ parameter that allows you to filter out your own logging layer.
+- `structlog.processors.StackInfoRenderer` now has an *additional_ignores* parameter that allows you to filter out your own logging layer.
   [#396](https://github.com/hynek/structlog/issues/396)
 - Added `structlog.WriteLogger`, a faster – but more low-level – alternative to `structlog.PrintLogger`.
   It works the way `PrintLogger` used to work in previous versions.
@@ -225,7 +250,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added structured logging of tracebacks via the `structlog.tracebacks` module,
   and most notably the `structlog.tracebacks.ExceptionDictTransformer` which can be used with the new `structlog.processors.ExceptionRenderer` to render JSON tracebacks.
   [#407](https://github.com/hynek/structlog/pull/407)
-- `structlog.stdlib.recreate_defaults(log_level=logging.NOTSET)` that recreates _structlog_'s defaults on top of standard library's `logging`.
+- `structlog.stdlib.recreate_defaults(log_level=logging.NOTSET)` that recreates *structlog*'s defaults on top of standard library's `logging`.
   It optionally also configures `logging` to log to standard out at the passed log level.
   [#428](https://github.com/hynek/structlog/pull/428)
 - `structlog.processors.EventRenamer` allows you to rename the hitherto hard-coded event dict key `event` to something else.
@@ -233,6 +258,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   So adding `EventRenamer(to="msg", replace_by="_event")` to your processor pipeline will rename the standard `event` key to `msg` and then rename the `_event` key to `event`.
   This allows you to use the `event` key in your own log files and to have consistent log message keys across languages.
 - `structlog.dev.ConsoleRenderer(event_key="event")` now allows to customize the name of the key that is used for the log message.
+
 
 ### Changed
 
@@ -247,7 +273,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   Its behavior has not changed.
   [#407](https://github.com/hynek/structlog/pull/407)
 - The default configuration now includes the `structlog.contextvars.merge_contextvars` processor.
-  That means you can use [`structlog.contextvars`](https://www.structlog.org/en/stable/contextvars.html) features without configuring _structlog_.
+  That means you can use [`structlog.contextvars`](https://www.structlog.org/en/stable/contextvars.html) features without configuring *structlog*.
+
 
 ### Fixed
 
@@ -261,11 +288,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#424](https://github.com/hynek/structlog/issues/424),
   [#427](https://github.com/hynek/structlog/issues/427)
 
+
 ## [21.5.0](https://github.com/hynek/structlog/compare/21.4.0...21.5.0) - 2021-12-16
 
 ### Added
 
-- Added the `structlog.processors.LogfmtRenderer` processor to render log lines using the [_logfmt_](https://brandur.org/logfmt) format.
+- Added the `structlog.processors.LogfmtRenderer` processor to render log lines using the [*logfmt*](https://brandur.org/logfmt) format.
   [#376](https://github.com/hynek/structlog/pull/376)
 - Added the `structlog.stdlib.ExtraAdder` processor that adds extra attributes of `logging.LogRecord` objects to the event dictionary.
   This processor can be used for adding data passed in the `extra` parameter of the `logging` module's log methods to the event dictionary.
@@ -275,6 +303,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   This processor can be used to enrich events dictionaries with information such as the function name, line number and filename that an event dictionary originated from.
   [#380](https://github.com/hynek/structlog/pull/380)
 
+
 ## [21.4.0](https://github.com/hynek/structlog/compare/21.3.0...21.4.0) - 2021-11-25
 
 ### Added
@@ -282,11 +311,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added the `structlog.threadlocal.bound_threadlocal` and `structlog.contextvars.bound_contextvars` decorator/context managers to temporarily bind key-value pairs to a thread-local and context-local context.
   [#371](https://github.com/hynek/structlog/pull/371)
 
+
 ### Fixed
 
 - Fixed import when running in optimized mode (`PYTHONOPTIMIZE=2` or `python -OO`)
-  .
+.
   [#373](https://github.com/hynek/structlog/pull/373)
+
 
 ## [21.3.0](https://github.com/hynek/structlog/compare/21.2.0...21.3.0) - 2021-11-20
 
@@ -295,25 +326,28 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.dev.ConsoleRenderer` now has `sort_keys` boolean parameter that allows to disable the sorting of keys on output.
   [#358](https://github.com/hynek/structlog/pull/358)
 
+
 ### Changed
 
-- _structlog_ switched its packaging to [_flit_](https://flit.pypa.io/).
+- *structlog* switched its packaging to [*flit*](https://flit.pypa.io/).
   Users shouldn't notice a difference, but (re-)packagers might.
 - `structlog.stdlib.AsyncBoundLogger` now determines the running loop when logging, not on instantiation.
-  That has a minor performance impact, but makes it more robust when loops change (for example, `aiohttp.web.run_app()`), or you want to use `sync_bl` _before_ a loop has started.
+  That has a minor performance impact, but makes it more robust when loops change (for example, `aiohttp.web.run_app()`), or you want to use `sync_bl` *before* a loop has started.
+
 
 ### Fixed
 
-- `structlog.processors.TimeStamper` now works well with [_FreezeGun_](https://github.com/spulec/freezegun) even when it gets applied before the loggers are configured.
+- `structlog.processors.TimeStamper` now works well with [*FreezeGun*](https://github.com/spulec/freezegun) even when it gets applied before the loggers are configured.
   [#364](https://github.com/hynek/structlog/pull/364)
 
-- `structlog.stdlib.ProcessorFormatter` now has a _processors_ argument that allows to define a processor chain to run over _all_ log entries.
+- `structlog.stdlib.ProcessorFormatter` now has a *processors* argument that allows to define a processor chain to run over *all* log entries.
 
   Before running the chain, two additional keys are added to the event dictionary: `_record` and `_from_structlog`.
-  With them it's possible to extract information from `logging.LogRecord`s and differentiate between _structlog_ and `logging` log entries while processing them.
+  With them it's possible to extract information from `logging.LogRecord`s and differentiate between *structlog* and `logging` log entries while processing them.
 
-  The old _processor_ (singular) parameter is now deprecated, but no plans exist to remove it.
+  The old *processor* (singular) parameter is now deprecated, but no plans exist to remove it.
   [#365](https://github.com/hynek/structlog/pull/365)
+
 
 ## [21.2.0](https://github.com/hynek/structlog/compare/21.1.0...21.2.0) - 2021-10-12
 
@@ -322,37 +356,38 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.threadlocal.get_threadlocal()` and `structlog.contextvars.get_contextvars()` can now be used to get a copy of the current thread-local/context-local context that has been bound using `structlog.threadlocal.bind_threadlocal()` and `structlog.contextvars.bind_contextvars()`.
   [#331](https://github.com/hynek/structlog/pull/331),
   [#337](https://github.com/hynek/structlog/pull/337)
-- `structlog.threadlocal.get_merged_threadlocal(bl)` and `structlog.contextvars.get_merged_contextvars(bl)` do the same, but also merge the context from a bound logger _bl_.
+- `structlog.threadlocal.get_merged_threadlocal(bl)` and `structlog.contextvars.get_merged_contextvars(bl)` do the same, but also merge the context from a bound logger *bl*.
   Same pull requests as previous change.
 - `structlog.contextvars.bind_contextvars()` now returns a mapping of keys to `contextvars.Token`s, allowing you to reset values using the new `structlog.contextvars.reset_contextvars()`.
   [#339](https://github.com/hynek/structlog/pull/339)
 - Exception rendering in `structlog.dev.ConsoleLogger` is now configurable using the `exception_formatter` setting.
-  If either the [Rich](https://github.com/Textualize/rich) or the [_better-exceptions_](https://github.com/qix-/better-exceptions) package is present, _structlog_ will use them for pretty-printing tracebacks.
-  Rich takes precedence over _better-exceptions_ if both are present.
+  If either the [Rich](https://github.com/Textualize/rich) or the [*better-exceptions*](https://github.com/qix-/better-exceptions) package is present, *structlog* will use them for pretty-printing tracebacks.
+  Rich takes precedence over *better-exceptions* if both are present.
 
   This only works if `format_exc_info` is **absent** in the processor chain.
   [#330](https://github.com/hynek/structlog/pull/330),
   [#349](https://github.com/hynek/structlog/pull/349)
-
 - The final processor can now return a `bytearray` (additionally to `str` and `bytes`).
   [#344](https://github.com/hynek/structlog/issues/344)
+
 
 ### Changed
 
 - To implement pretty exceptions (see Changes below), `structlog.dev.ConsoleRenderer` now formats exceptions itself.
 
-  Make sure to remove `format_exc_info` from your processor chain if you configure _structlog_ manually.
+  Make sure to remove `format_exc_info` from your processor chain if you configure *structlog* manually.
   This change is not really breaking, because the old use-case will keep working as before.
   However if you pass `pretty_exceptions=True` (which is the default if either `rich` or `better-exceptions` is installed), a warning will be raised and the exception will be rendered without prettification.
-
 - All use of [Colorama](https://github.com/tartley/colorama) on non-Windows systems has been excised.
   Thus, colors are now enabled by default in `structlog.dev.ConsoleRenderer` on non-Windows systems.
   You can keep using Colorama to customize colors, of course.
   [#345](https://github.com/hynek/structlog/pull/345)
 
+
 ### Fixed
 
-- _structlog_ is now importable if `sys.stdout` is `None` (for example, when running using `pythonw`). [#313](https://github.com/hynek/structlog/issues/313)
+- *structlog* is now importable if `sys.stdout` is `None` (for example, when running using `pythonw`). [#313](https://github.com/hynek/structlog/issues/313)
+
 
 ## [21.1.0](https://github.com/hynek/structlog/compare/20.2.0...21.1.0) - 2021-02-18
 
@@ -360,6 +395,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `structlog.dev.ConsoleRenderer` will now look for a `logger_name` key if no `logger` key is set.
   [#295](https://github.com/hynek/structlog/pull/295)
+
 
 ### Fixed
 
@@ -370,6 +406,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - The default configuration and loggers are pickleable again.
   [#301](https://github.com/hynek/structlog/pull/301)
 
+
 ## [20.2.0](https://github.com/hynek/structlog/compare/20.1.0...20.2.0) - 2020-12-31
 
 ### Removed
@@ -378,27 +415,28 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   The package meta data should ensure that you keep getting 20.1.0 on those versions.
   [#244](https://github.com/hynek/structlog/pull/244)
 
+
 ### Deprecated
 
 - Accessing the `_context` attribute of a bound logger is now deprecated.
   Please use the new `structlog.get_context()`.
 
+
 ### Added
 
-- _structlog_ has now type hints for all of its APIs!
-  Since _structlog_ is highly dynamic and configurable, this led to a few concessions like a specialized `structlog.stdlib.get_logger()` whose only difference to `structlog.get_logger()` is that it has the correct type hints.
+- *structlog* has now type hints for all of its APIs!
+  Since *structlog* is highly dynamic and configurable, this led to a few concessions like a specialized `structlog.stdlib.get_logger()` whose only difference to `structlog.get_logger()` is that it has the correct type hints.
 
   We consider them provisional for the time being – that means the backwards-compatibility does not apply to them in its full strength until we feel we got it right.
   Please feel free to provide feedback!
   [#223](https://github.com/hynek/structlog/issues/223),
   [#282](https://github.com/hynek/structlog/issues/282)
-
 - Added `structlog.make_filtering_logger` that can be used like `configure(wrapper_class=make_filtering_bound_logger(logging.INFO))`.
   It creates a highly optimized bound logger whose inactive methods only consist of a `return None`.
   This is now also the default logger.
 - As a complement, `structlog.stdlib.add_log_level()` can now additionally be imported as `structlog.processors.add_log_level` since it just adds the method name to the event dict.
 - Added `structlog.BytesLogger` to avoid unnecessary encoding round trips.
-  Concretely this is useful with _orjson_ which returns bytes.
+  Concretely this is useful with *orjson* which returns bytes.
   [#271](https://github.com/hynek/structlog/issues/271)
 - The final processor now also may return bytes that are passed untouched to the wrapped logger.
 - `structlog.get_context()` allows you to retrieve the original context of a bound logger. [#266](https://github.com/hynek/structlog/issues/266),
@@ -406,23 +444,25 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added `structlog.stdlib.AsyncBoundLogger` that executes logging calls in a thread executor and therefore doesn't block.
   [#245](https://github.com/hynek/structlog/pull/245)
 
+
 ### Changed
 
-- The default bound logger (`wrapper_class`) if you don't configure _structlog_ has changed.
+- The default bound logger (`wrapper_class`) if you don't configure *structlog* has changed.
   It's mostly compatible with the old one but a few uncommon methods like `log`, `failure`, or `err` don't exist anymore.
 
   You can regain the old behavior by using `structlog.configure(wrapper_class=structlog.BoundLogger)`.
 
   Please note that due to the various interactions between settings, it's possible that you encounter even more errors.
-  We **strongly** urge you to always configure all possible settings since the default configuration is _not_ covered by our backwards-compatibility policy.
-
+  We **strongly** urge you to always configure all possible settings since the default configuration is *not* covered by our backwards-compatibility policy.
 - `structlog.processors.add_log_level()` is now part of the default configuration.
 - `structlog.stdlib.ProcessorFormatter` no longer uses exceptions for control flow, allowing `foreign_pre_chain` processors to use `sys.exc_info()` to access the real exception.
+
 
 ### Fixed
 
 - `structlog.PrintLogger` now supports `copy.deepcopy()`.
   [#268](https://github.com/hynek/structlog/issues/268)
+
 
 ## [20.1.0](https://github.com/hynek/structlog/compare/19.2.0...20.1.0) - 2020-01-28
 
@@ -431,9 +471,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - This is the last version to support Python 2.7 (including PyPy) and 3.5.
   All following versions will only support Python 3.6 or later.
 
+
 ### Added
 
-- Added a new module `structlog.contextvars` that allows to have a global but context-local _structlog_ context the same way as with `structlog.threadlocal` since 19.2.0.
+- Added a new module `structlog.contextvars` that allows to have a global but context-local *structlog* context the same way as with `structlog.threadlocal` since 19.2.0.
   [#201](https://github.com/hynek/structlog/issues/201),
   [#236](https://github.com/hynek/structlog/pull/236)
 - Added a new module `structlog.testing` for first class testing support.
@@ -443,6 +484,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added `structlog.threadlocal.unbind_threadlocal()`.
   [#239](https://github.com/hynek/structlog/pull/239)
 
+
 ### Fixed
 
 - The logger created by `structlog.get_logger()` is not detected as an abstract method anymore, when attached to an abstract base class.
@@ -451,14 +493,16 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#232](https://github.com/hynek/structlog/issues/232),
   [#242](https://github.com/hynek/structlog/pull/242)
 
+
 ## [19.2.0](https://github.com/hynek/structlog/compare/19.1.0...19.2.0) - 2019-10-16
 
 ### Removed
 
 - Python 3.4 is not supported anymore.
-  It has been unsupported by the Python core team for a while now and its PyPI downloads are negligible.
+It has been unsupported by the Python core team for a while now and its PyPI downloads are negligible.
 
-  It's very unlikely that _structlog_ will break under 3.4 anytime soon, but we don't test it anymore.
+  It's very unlikely that *structlog* will break under 3.4 anytime soon, but we don't test it anymore.
+
 
 ### Added
 
@@ -466,7 +510,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added more pass-through properties to `structlog.stdlib.BoundLogger`. To makes it easier to use it as a drop-in replacement for `logging.Logger`.
   [#198](https://github.com/hynek/structlog/issues/198)
 - Added new processor `structlog.dev.set_exc_info()` that will set `exc_info=True` if the method's name is `exception` and `exc_info` isn't set at all.
-  _This is only necessary when the standard library integration is not used_.
+  *This is only necessary when the standard library integration is not used*.
   It fixes the problem that in the default configuration, `structlog.get_logger().exception("hi")` in an `except` block would not print the exception without passing `exc_info=True` to it explicitly.
   [#130](https://github.com/hynek/structlog/issues/130),
   [#173](https://github.com/hynek/structlog/issues/173),
@@ -475,8 +519,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added a new thread-local API that allows binding values to a thread-local context explicitly without affecting the default behavior of `bind()`.
   [#222](https://github.com/hynek/structlog/issues/222),
   [#225](https://github.com/hynek/structlog/issues/225)
-- Added _pass_foreign_args_ argument to `structlog.stdlib.ProcessorFormatter`. It allows to pass a foreign log record's _args_ attribute to the event dictionary under the `positional_args` key.
+- Added *pass_foreign_args* argument to `structlog.stdlib.ProcessorFormatter`. It allows to pass a foreign log record's *args* attribute to the event dictionary under the `positional_args` key.
   [#228](https://github.com/hynek/structlog/issues/228)
+
+
 
 ### Changed
 
@@ -485,18 +531,20 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#219](https://github.com/hynek/structlog/issues/219)
 - `structlog.dev.ConsoleRenderer` now calls `str()` on the event value. [#221](https://github.com/hynek/structlog/issues/221)
 
+
 ### Fixed
 
 - `structlog.dev.ConsoleRenderer` now uses no colors by default, if Colorama is not available.
   [#215](https://github.com/hynek/structlog/issues/215)
-- `structlog.dev.ConsoleRenderer` now initializes Colorama lazily, to prevent accidental side-effects just by importing _structlog_.
+- `structlog.dev.ConsoleRenderer` now initializes Colorama lazily, to prevent accidental side-effects just by importing *structlog*.
   [#210](https://github.com/hynek/structlog/issues/210)
-- A best effort has been made to make as much of _structlog_ pickleable as possible to make it friendlier with `multiprocessing` and similar libraries.
+- A best effort has been made to make as much of *structlog* pickleable as possible to make it friendlier with `multiprocessing` and similar libraries.
   Some classes can only be pickled on Python 3 or using the [dill](https://pypi.org/project/dill/) library though and that is very unlikely to change.
 
   So far, the configuration proxy, `structlog.processor.TimeStamper`, `structlog.BoundLogger`, `structlog.PrintLogger` and `structlog.dev.ConsoleRenderer` have been made pickleable.
   Please report if you need any another class fixed.
   [#126](https://github.com/hynek/structlog/issues/126)
+
 
 ## [19.1.0](https://github.com/hynek/structlog/compare/18.2.0...19.1.0) - 2019-02-02
 
@@ -505,14 +553,16 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.ReturnLogger` and `structlog.PrintLogger` now have a `fatal()` log method.
   [#181](https://github.com/hynek/structlog/issues/181)
 
+
 ### Changed
 
 - As announced in 18.1.0, `pip install -e .[dev]` now installs all development dependencies.
   Sorry for the inconveniences this undoubtedly will cause!
-- _structlog_ now tolerates passing through `dict`s to stdlib logging.
+- *structlog* now tolerates passing through `dict`s to stdlib logging.
   [#187](https://github.com/hynek/structlog/issues/187),
   [#188](https://github.com/hynek/structlog/pull/188),
   [#189](https://github.com/hynek/structlog/pull/189)
+
 
 ### Fixed
 
@@ -520,36 +570,40 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   A workaround has been added.
   [#174](https://github.com/hynek/structlog/issues/174)
 
+
 ## [18.2.0](https://github.com/hynek/structlog/compare/18.1.0...18.2.0) - 2018-09-05
 
 ### Added
 
-- Added `structlog.stdlib.add_log_level_number()` processor that adds the level _number_ to the event dictionary.
+- Added `structlog.stdlib.add_log_level_number()` processor that adds the level *number* to the event dictionary.
   Can be used to simplify log filtering.
   [#151](https://github.com/hynek/structlog/pull/151)
-- `structlog.processors.JSONRenderer` now allows for overwriting the _default_ argument of its serializer.
+- `structlog.processors.JSONRenderer` now allows for overwriting the *default* argument of its serializer.
   [#77](https://github.com/hynek/structlog/pull/77),
   [#163](https://github.com/hynek/structlog/pull/163)
 - Added `try_unbind()` that works like `unbind()` but doesn't raise a `KeyError` if one of the keys is missing.
   [#171](https://github.com/hynek/structlog/pull/171)
 
+
 ## [18.1.0](https://github.com/hynek/structlog/compare/17.2.0...18.1.0) - 2018-01-27
 
 ### Deprecated
 
-- The meaning of the `structlog[dev]` installation target will change from "colorful output" to "dependencies to develop _structlog_" in 19.1.0.
+- The meaning of the `structlog[dev]` installation target will change from "colorful output" to "dependencies to develop *structlog*" in 19.1.0.
 
-  The main reason behind this decision is that it's impossible to have a _structlog_ in your normal dependencies and additionally a `structlog[dev]` for development (`pip` will report an error).
+  The main reason behind this decision is that it's impossible to have a *structlog* in your normal dependencies and additionally a `structlog[dev]` for development (`pip` will report an error).
+
 
 ### Added
 
-- `structlog.dev.ConsoleRenderer` now accepts a _force_colors_ argument to output colored logs even if the destination is not a tty.
+- `structlog.dev.ConsoleRenderer` now accepts a *force_colors* argument to output colored logs even if the destination is not a tty.
   Use this option if your logs are stored in files that are intended to be streamed to the console.
-- `structlog.dev.ConsoleRenderer` now accepts a _level_styles_ argument for overriding the colors for individual levels, as well as to add new levels.
+- `structlog.dev.ConsoleRenderer` now accepts a *level_styles* argument for overriding the colors for individual levels, as well as to add new levels.
   See the docs for `ConsoleRenderer.get_default_level_styles()` for usage.
   [#139](https://github.com/hynek/structlog/pull/139)
-- Added `structlog.is_configured()` to check whether or not _structlog_ has been configured.
+- Added `structlog.is_configured()` to check whether or not *structlog* has been configured.
 - Added `structlog.get_config()` to introspect current configuration.
+
 
 ### Changed
 
@@ -558,21 +612,22 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.stdlib.BoundLogger.exception()` now uses the `exc_info` argument if it has been passed instead of setting it unconditionally to `True`. [#149](https://github.com/hynek/structlog/pull/149)
 - Default configuration now uses plain `dict`s on Python 3.6+ and PyPy since they are ordered by default.
 
-### Fixed
 
+### Fixed
 - Do not encapsulate Twisted failures twice with newer versions of Twisted.
   [#144](https://github.com/hynek/structlog/issues/144)
+
 
 ## [17.2.0](https://github.com/hynek/structlog/compare/17.1.0...17.2.0) - 2017-05-15
 
 ### Added
 
-- `structlog.stdlib.ProcessorFormatter` now accepts _keep_exc_info_ and _keep_stack_info_ arguments to control what to do with this information on log records.
+- `structlog.stdlib.ProcessorFormatter` now accepts *keep_exc_info* and *keep_stack_info* arguments to control what to do with this information on log records.
   Most likely you want them both to be `False` therefore it's the default.
   [#109](https://github.com/hynek/structlog/issues/109)
 
-### Fixed
 
+### Fixed
 - `structlog.stdlib.add_logger_name()` now works in `structlog.stdlib.ProcessorFormatter`'s `foreign_pre_chain`.
   [#112](https://github.com/hynek/structlog/issues/112)
 - Clear log record args in `structlog.stdlib.ProcessorFormatter` after rendering.
@@ -580,41 +635,46 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#116](https://github.com/hynek/structlog/issues/116),
   [#117](https://github.com/hynek/structlog/issues/117)
 
+
 ## [17.1.0](https://github.com/hynek/structlog/compare/16.1.0...17.1.0) - 2017-04-24
 
 The main features of this release are massive improvements in standard library's `logging` integration.
 Have a look at the updated [standard library chapter](https://www.structlog.org/en/stable/standard-library.html) on how to use them!
 Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilbert Gilb's](https://github.com/gilbsgilbs), [Iva Kaneva](https://github.com/if-fi), [insolite](https://github.com/insolite), and [sky-code](https://github.com/sky-code), that made them possible.
 
+
 ### Added
 
 - Added `structlog.stdlib.render_to_log_kwargs()`.
   This allows you to use `logging`-based formatters to take care of rendering your entries.
   [#98](https://github.com/hynek/structlog/issues/98)
-- Added `structlog.stdlib.ProcessorFormatter` which does the opposite: This allows you to run _structlog_ processors on arbitrary `logging.LogRecords`.
+- Added `structlog.stdlib.ProcessorFormatter` which does the opposite: This allows you to run *structlog* processors on arbitrary `logging.LogRecords`.
   [#79](https://github.com/hynek/structlog/issues/79),
   [#105](https://github.com/hynek/structlog/issues/105)
-- Added _repr_native_str_ to `structlog.processors.KeyValueRenderer` and `structlog.dev.ConsoleRenderer`.
+- Added *repr_native_str* to `structlog.processors.KeyValueRenderer` and `structlog.dev.ConsoleRenderer`.
   This allows for human-readable non-ASCII output on Python 2 (`repr()` on Python 2 behaves like `ascii()` on Python 3 in that regard).
   As per compatibility policy, it's on (original behavior) in `KeyValueRenderer` and off (human-friendly behavior) in `ConsoleRenderer`.
   [#94](https://github.com/hynek/structlog/issues/94)
-- Added _colors_ argument to `structlog.dev.ConsoleRenderer` and made it the default renderer.
+- Added *colors* argument to `structlog.dev.ConsoleRenderer` and made it the default renderer.
   [#78](https://github.com/hynek/structlog/pull/78)
+
 
 ### Changed
 
-- The default renderer now is `structlog.dev.ConsoleRenderer` if you don't configure _structlog_.
+- The default renderer now is `structlog.dev.ConsoleRenderer` if you don't configure *structlog*.
   Colors are used if available and human-friendly timestamps are prepended.
   This is in line with our backwards-compatibility policy that explicitly excludes default settings.
 - UNIX epoch timestamps from `structlog.processors.TimeStamper` are more precise now.
 - Positional arguments are now removed even if they are empty.
   [#82](https://github.com/hynek/structlog/pull/82)
 
+
 ## Fixed
 
 - Fixed bug with Python 3 and `structlog.stdlib.BoundLogger.log()`.
   Error log level was not reproducible and was logged as exception one time out of two.
   [#92](https://github.com/hynek/structlog/pull/92)
+
 
 ## [16.1.0](https://github.com/hynek/structlog/compare/16.0.0...16.1.0) - 2016-05-24
 
@@ -628,11 +688,13 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 
   Python 3.3 never had a significant user base and wasn't part of any distribution's LTS release.
 
+
 ### Added
 
 - Added a `drop_missing` argument to `KeyValueRenderer`.
   If `key_order` is used and a key is missing a value, it's not rendered at all instead of being rendered as `None`.
   [#67](https://github.com/hynek/structlog/pull/67)
+
 
 ### Fixed
 
@@ -640,6 +702,7 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Don't cache loggers in lazy proxies returned from `get_logger()`.
   This lead to in-place mutation of them if used before configuration which in turn lead to the problem that configuration was applied only partially to them later.
   [#72](https://github.com/hynek/structlog/pull/72)
+
 
 ## [16.0.0](https://github.com/hynek/structlog/compare/15.3.0...16.0.0) - 2016-01-28
 
@@ -649,10 +712,12 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added `structlog.processors.UnicodeDecoder` that will decode all byte string values in an event dictionary to Unicode.
 - Added `serializer` parameter to `structlog.processors.JSONRenderer` which allows for using different (possibly faster) JSON encoders than the standard library.
 
+
 ### Changed
 
 - `structlog.processors.ExceptionPrettyPrinter` and `structlog.processors.format_exc_info` now support passing of Exceptions on Python 3.
-- [_six_](https://six.readthedocs.io/) is now used for compatibility.
+- [*six*](https://six.readthedocs.io/) is now used for compatibility.
+
 
 ### Fixed
 
@@ -661,6 +726,7 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Be more more lenient about missing `__name__`s.
   [#62](https://github.com/hynek/structlog/pull/62)
 
+
 ## [15.3.0](https://github.com/hynek/structlog/compare/15.2.0...15.3.0) - 2015-09-25
 
 ### Added
@@ -668,10 +734,12 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Officially support Python 3.5.
 - Added `structlog.ReturnLogger.failure` and `structlog.PrintLogger.failure` as preparation for the new Twisted logging system.
 
+
 ### Fixed
 
 - Tolerate frames without a `__name__`, better.
   [#58](https://github.com/hynek/structlog/pull/58)
+
 
 ## [15.2.0](https://github.com/hynek/structlog/compare/15.1.0...15.2.0) - 2015-06-10
 
@@ -680,23 +748,27 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added option to specify target key in `structlog.processors.TimeStamper` processor.
   [#51](https://github.com/hynek/structlog/pull/51)
 
+
 ### Changed
 
 - Allow empty lists of processors.
   This is a valid use case since [#26](https://github.com/hynek/structlog/issues/26) has been merged.
   Before, supplying an empty list resulted in the defaults being used.
-- Better support of `logging.Logger.exception` within _structlog_.
+- Better support of `logging.Logger.exception` within *structlog*.
   [#52](https://github.com/hynek/structlog/pull/52)
+
 
 ### Fixed
 
 - Prevent Twisted's `log.err` from quoting strings rendered by `structlog.twisted.JSONRenderer`.
+
 
 ## [15.1.0](https://github.com/hynek/structlog/compare/15.0.0...15.1.0) - 2015-02-24
 
 ### Fixed
 
 - Tolerate frames without a `__name__` when guessing callsite names.
+
 
 ## [15.0.0](https://github.com/hynek/structlog/compare/0.4.2...15.0.0) - 2015-01-23
 
@@ -709,13 +781,15 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added `structlog.stdlib.BoundLogger.exception`.
   [#22](https://github.com/hynek/structlog/pull/22)
 
+
 ### Changed
 
 - Pass positional arguments to stdlib wrapped loggers that use string formatting.
   [#19](https://github.com/hynek/structlog/pull/19)
-- _structlog_ is now dually licensed under the [Apache License, Version 2](https://choosealicense.com/licenses/apache/) and the [MIT](https://choosealicense.com/licenses/mit/) license.
-  Therefore it is now legal to use _structlog_ with [GPLv2](https://choosealicense.com/licenses/gpl-2.0/)-licensed projects.
+- *structlog* is now dually licensed under the [Apache License, Version 2](https://choosealicense.com/licenses/apache/) and the [MIT](https://choosealicense.com/licenses/mit/) license.
+  Therefore it is now legal to use *structlog* with [GPLv2](https://choosealicense.com/licenses/gpl-2.0/)-licensed projects.
   [#28](https://github.com/hynek/structlog/pull/28)
+
 
 ## [0.4.2](https://github.com/hynek/structlog/compare/0.4.1...0.4.2) - 2014-07-26
 
@@ -725,6 +799,7 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   There is no justification to add complexity for a Python version that nobody uses.
   If you are one of the [0.350%](https://alexgaynor.net/2014/jan/03/pypi-download-statistics/) that use Python 3.2, please stick to the 0.4 branch; critical bugs will still be fixed.
 
+
 ### Added
 
 - Officially support Python 3.4.
@@ -732,6 +807,7 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   See the adapting chapter.
   [#26](https://github.com/hynek/structlog/issues/26)
 - Test Twisted-related code on Python 3 (with some caveats).
+
 
 ### Fixed
 
@@ -741,15 +817,18 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - `structlog.PrintLogger` now is thread-safe.
 - `from structlog import *` works now (but you still shouldn't use it).
 
+
 ## [0.4.1](https://github.com/hynek/structlog/compare/0.4.0...0.4.1) - 2013-12-19
 
 ### Changed
 
 - Don't cache proxied methods in `structlog.threadlocal._ThreadLocalDictWrapper`. This doesn't affect regular users.
 
+
 ### Fixed
 
 - Various doc fixes.
+
 
 ## [0.4.0](https://github.com/hynek/structlog/compare/0.3.2...0.4.0) - 2013-11-10
 
@@ -766,17 +845,20 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   This is useful together with frameworks.
 - Add meta data (for example, function names, line numbers) extraction for wrapped stdlib loggers. [#5](https://github.com/hynek/structlog/pull/5)
 
+
 ## [0.3.2](https://github.com/hynek/structlog/compare/0.3.1...0.3.2) - 2013-09-27
 
 ### Fixed
 
 - Fix stdlib's name guessing.
 
+
 ## [0.3.1](https://github.com/hynek/structlog/compare/0.3.0...0.3.1) - 2013-09-26
 
 ### Fixed
 
 - Added forgotten `structlog.processors.TimeStamper` to API documentation.
+
 
 ## [0.3.0](https://github.com/hynek/structlog/compare/0.2.0...0.3.0) - 2013-09-23
 
@@ -793,6 +875,7 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Extract a common base class for loggers that does nothing except keeping the context state.
   This makes writing custom loggers much easier and more straight-forward. See `structlog.BoundLoggerBase`.
 
+
 ## [0.2.0](https://github.com/hynek/structlog/compare/0.1.0...0.2.0) - 2013-09-17
 
 ### Added
@@ -801,10 +884,12 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Enhance Twisted support by offering JSONification of non-structlog log entries.
 - Allow for custom serialization in `structlog.twisted.JSONRenderer` without abusing `__repr__`.
 
+
 ### Changed
 
 - Promote to stable, thus henceforth a strict backwards-compatibility policy is put into effect.
 - `structlog.PrintLogger` now uses proper I/O routines and is thus viable not only for examples but also for production.
+
 
 ## [0.1.0](https://github.com/hynek/structlog/tree/0.1.0) - 2013-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 <!-- changelog follows -->
 
-
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.2.0...HEAD)
 
+- capture_logs now map exception log level to error
 
 ## [24.2.0](https://github.com/hynek/structlog/compare/24.1.0...24.2.0) - 2024-05-27
 
@@ -29,7 +29,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.CallsiteParameterAdder` now also works with `structlog.stdlib.BoundLogger`'s non-standard async methods (`ainfo()`, and so forth)
   [#618](https://github.com/hynek/structlog/pull/618)
 
-
 ### Changed
 
 - `structlog.processors.LogfmtRenderer` now escapes newlines.
@@ -41,13 +40,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.CallsiteParameterAdder` has been optimized to be about 2x faster.
   [#606](https://github.com/hynek/structlog/pull/606)
 
-
 ### Fixed
 
 - `structlog.stdlib.render_to_log_kwargs` now correctly passes stacklevel as a kwarg to stdlib logging.
   [#619](https://github.com/hynek/structlog/pull/620)
-
-
 
 ## [24.1.0](https://github.com/hynek/structlog/compare/23.3.0...24.1.0) - 2024-01-08
 
@@ -63,7 +59,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Don't ignore the `width` argument of `RichTracebackFormatter`.
   [#587](https://github.com/hynek/structlog/issues/587)
 
-
 ## [23.3.0](https://github.com/hynek/structlog/compare/23.2.0...23.3.0) - 2023-12-29
 
 ### Added
@@ -78,12 +73,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Async log methods (those starting with an `a`) now also support the collection of callsite information using `structlog.processors.CallsiteParameterAdder`.
   [#565](https://github.com/hynek/structlog/issues/565)
 
-
 ### Changed
 
 - `structlog.stdlib.recreate_defaults()` now also adds `structlog.stdlib.add_logger_name` to the processors.
   Check out the [updated screenshot](https://raw.githubusercontent.com/hynek/structlog/main/docs/_static/console_renderer.png)!
-
 
 ### Fixed
 
@@ -99,13 +92,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#571](https://github.com/hynek/structlog/issues/571)
   [#572](https://github.com/hynek/structlog/issues/572)
 
-
 ## [23.2.0](https://github.com/hynek/structlog/compare/23.1.0...23.2.0) - 2023-10-09
 
 ### Removed
 
 - Support for Python 3.7.
-
 
 ### Added
 
@@ -115,20 +106,18 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.processors.MaybeTimeStamper` that only adds a timestamp if there isn't one already.
   [#81](https://github.com/hynek/structlog/issues/81)
 
-- `structlog.dev.ConsoleRenderer` now supports renamed timestamp keys using the *timestamp_key* parameter.
+- `structlog.dev.ConsoleRenderer` now supports renamed timestamp keys using the _timestamp_key_ parameter.
   [#541](https://github.com/hynek/structlog/issues/541)
 
 - `structlog.dev.RichTracebackFormatter` that allows to configure the traceback formatting.
   [#542](https://github.com/hynek/structlog/issues/542)
 
-
 ### Fixed
 
-- `FilteringBoundLogger.exception()` and  `FilteringBoundLogger.aexception()` now support positional argument formatting like the rest of the methods.
+- `FilteringBoundLogger.exception()` and `FilteringBoundLogger.aexception()` now support positional argument formatting like the rest of the methods.
   [#531](https://github.com/hynek/structlog/issues/531)
 - `structlog.processors.format_exc_info()` and `structlog.dev.ConsoleRenderer` do not crash anymore when told to format a non-existent exception.
   [#533](https://github.com/hynek/structlog/issues/533)
-
 
 ## [23.1.0](https://github.com/hynek/structlog/compare/22.3.0...23.1.0) - 2023-04-06
 
@@ -145,41 +134,36 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   This disables all heuristics whether it makes sense to use colors and overrides `FORCE_COLOR`.
   [#504](https://github.com/hynek/structlog/issues/504)
 
-
 ### Fixed
 
 - ConsoleRenderer now reuses the `_figure_out_exc_info` to process the `exc_info` argument like `ExceptionRenderer` does.
-  This prevents crashes if the actual Exception is passed for the *exc_info* argument instead of a tuple or `True`.
+  This prevents crashes if the actual Exception is passed for the _exc_info_ argument instead of a tuple or `True`.
   [#482](https://github.com/hynek/structlog/issues/482)
 
 - `FilteringBoundLogger.aexception()` now extracts the exception info using `sys.exc_info()` before passing control to the asyncio executor (where original exception info is no longer available).
   [#488](https://github.com/hynek/structlog/issues/488)
-
 
 ## [22.3.0](https://github.com/hynek/structlog/compare/22.2.0...22.3.0) - 2022-11-24
 
 ### Changed
 
 - String interpolation in `FilteringBoundLogger` (used by default) is now only attempted if positional arguments are passed.
-  This prevents crashes if something different than a string is passed for the *event* argument.
+  This prevents crashes if something different than a string is passed for the _event_ argument.
   [#475](https://github.com/hynek/structlog/pull/475)
-
 
 ### Fixed
 
 - String interpolation doesn't cause crashes in filtered log call anymore.
   [#478](https://github.com/hynek/structlog/pull/478)
 
-
 ## [22.2.0](https://github.com/hynek/structlog/compare/22.1.0...22.2.0) - 2022-11-19
 
 ### Deprecated
 
-- Accessing package metadata as attributes on the *structlog* module is deprecated (for example, `structlog.__version__`).
-  Please use [`importlib.metadata`](https://docs.python.org/3.10/library/importlib.metadata.html) instead (for Python 3.7: the [*importlib-metadata*](https://pypi.org/project/importlib-metadata/) PyPI package).
+- Accessing package metadata as attributes on the _structlog_ module is deprecated (for example, `structlog.__version__`).
+  Please use [`importlib.metadata`](https://docs.python.org/3.10/library/importlib.metadata.html) instead (for Python 3.7: the [_importlib-metadata_](https://pypi.org/project/importlib-metadata/) PyPI package).
 - The `structlog.types` module is now deprecated in favor of the `structlog.typing` module.
   It seems like the Python typing community is settling on this name.
-
 
 ### Added
 
@@ -192,26 +176,23 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
   [#454](https://github.com/hynek/structlog/pull/454)
 
-- `FilteringBoundLogger` now also has support for *asyncio*-based logging.
+- `FilteringBoundLogger` now also has support for _asyncio_-based logging.
   Instead of a wrapper class like `structlog.stdlib.AsyncBoundLogger`, async equivalents have been added for all logging methods.
   So instead of `log.info("hello")` you can also write `await log.ainfo("hello")` in async functions and methods.
 
   This seems like the better approach and if it's liked by the community, `structlog.stdlib.BoundLogger` will get those methods too.
   [#457](https://github.com/hynek/structlog/pull/457)
 
-
 ### Changed
 
 - The documentation has been **heavily** overhauled.
   Have a look if you haven't lately!
   Especially the graphs in the [standard library chapter](https://www.structlog.org/en/latest/standard-library.html) have proven valuable to many.
-- The build backend has been switched to [*Hatch*](https://hatch.pypa.io/).
-
+- The build backend has been switched to [_Hatch_](https://hatch.pypa.io/).
 
 ### Fixed
 
 - The timestamps in the default configuration now use the correct separator (`:`) for seconds.
-
 
 ## [22.1.0](https://github.com/hynek/structlog/compare/21.5.0...22.1.0) - 2022-07-20
 
@@ -219,7 +200,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - Python 3.6 is not supported anymore.
 - Pickling is now only possible with protocol version 3 and newer.
-
 
 ### Deprecated
 
@@ -232,10 +212,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   Currently there are no concrete plans to remove the module, but no patches against it will be accepted from now on.
   [#409](https://github.com/hynek/structlog/pull/409)
 
-
 ### Added
 
-- `structlog.processors.StackInfoRenderer` now has an *additional_ignores* parameter that allows you to filter out your own logging layer.
+- `structlog.processors.StackInfoRenderer` now has an _additional_ignores_ parameter that allows you to filter out your own logging layer.
   [#396](https://github.com/hynek/structlog/issues/396)
 - Added `structlog.WriteLogger`, a faster – but more low-level – alternative to `structlog.PrintLogger`.
   It works the way `PrintLogger` used to work in previous versions.
@@ -246,7 +225,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added structured logging of tracebacks via the `structlog.tracebacks` module,
   and most notably the `structlog.tracebacks.ExceptionDictTransformer` which can be used with the new `structlog.processors.ExceptionRenderer` to render JSON tracebacks.
   [#407](https://github.com/hynek/structlog/pull/407)
-- `structlog.stdlib.recreate_defaults(log_level=logging.NOTSET)` that recreates *structlog*'s defaults on top of standard library's `logging`.
+- `structlog.stdlib.recreate_defaults(log_level=logging.NOTSET)` that recreates _structlog_'s defaults on top of standard library's `logging`.
   It optionally also configures `logging` to log to standard out at the passed log level.
   [#428](https://github.com/hynek/structlog/pull/428)
 - `structlog.processors.EventRenamer` allows you to rename the hitherto hard-coded event dict key `event` to something else.
@@ -254,7 +233,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   So adding `EventRenamer(to="msg", replace_by="_event")` to your processor pipeline will rename the standard `event` key to `msg` and then rename the `_event` key to `event`.
   This allows you to use the `event` key in your own log files and to have consistent log message keys across languages.
 - `structlog.dev.ConsoleRenderer(event_key="event")` now allows to customize the name of the key that is used for the log message.
-
 
 ### Changed
 
@@ -269,8 +247,7 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   Its behavior has not changed.
   [#407](https://github.com/hynek/structlog/pull/407)
 - The default configuration now includes the `structlog.contextvars.merge_contextvars` processor.
-  That means you can use [`structlog.contextvars`](https://www.structlog.org/en/stable/contextvars.html) features without configuring *structlog*.
-
+  That means you can use [`structlog.contextvars`](https://www.structlog.org/en/stable/contextvars.html) features without configuring _structlog_.
 
 ### Fixed
 
@@ -284,12 +261,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#424](https://github.com/hynek/structlog/issues/424),
   [#427](https://github.com/hynek/structlog/issues/427)
 
-
 ## [21.5.0](https://github.com/hynek/structlog/compare/21.4.0...21.5.0) - 2021-12-16
 
 ### Added
 
-- Added the `structlog.processors.LogfmtRenderer` processor to render log lines using the [*logfmt*](https://brandur.org/logfmt) format.
+- Added the `structlog.processors.LogfmtRenderer` processor to render log lines using the [_logfmt_](https://brandur.org/logfmt) format.
   [#376](https://github.com/hynek/structlog/pull/376)
 - Added the `structlog.stdlib.ExtraAdder` processor that adds extra attributes of `logging.LogRecord` objects to the event dictionary.
   This processor can be used for adding data passed in the `extra` parameter of the `logging` module's log methods to the event dictionary.
@@ -299,7 +275,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   This processor can be used to enrich events dictionaries with information such as the function name, line number and filename that an event dictionary originated from.
   [#380](https://github.com/hynek/structlog/pull/380)
 
-
 ## [21.4.0](https://github.com/hynek/structlog/compare/21.3.0...21.4.0) - 2021-11-25
 
 ### Added
@@ -307,13 +282,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added the `structlog.threadlocal.bound_threadlocal` and `structlog.contextvars.bound_contextvars` decorator/context managers to temporarily bind key-value pairs to a thread-local and context-local context.
   [#371](https://github.com/hynek/structlog/pull/371)
 
-
 ### Fixed
 
 - Fixed import when running in optimized mode (`PYTHONOPTIMIZE=2` or `python -OO`)
-.
+  .
   [#373](https://github.com/hynek/structlog/pull/373)
-
 
 ## [21.3.0](https://github.com/hynek/structlog/compare/21.2.0...21.3.0) - 2021-11-20
 
@@ -322,28 +295,25 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.dev.ConsoleRenderer` now has `sort_keys` boolean parameter that allows to disable the sorting of keys on output.
   [#358](https://github.com/hynek/structlog/pull/358)
 
-
 ### Changed
 
-- *structlog* switched its packaging to [*flit*](https://flit.pypa.io/).
+- _structlog_ switched its packaging to [_flit_](https://flit.pypa.io/).
   Users shouldn't notice a difference, but (re-)packagers might.
 - `structlog.stdlib.AsyncBoundLogger` now determines the running loop when logging, not on instantiation.
-  That has a minor performance impact, but makes it more robust when loops change (for example, `aiohttp.web.run_app()`), or you want to use `sync_bl` *before* a loop has started.
-
+  That has a minor performance impact, but makes it more robust when loops change (for example, `aiohttp.web.run_app()`), or you want to use `sync_bl` _before_ a loop has started.
 
 ### Fixed
 
-- `structlog.processors.TimeStamper` now works well with [*FreezeGun*](https://github.com/spulec/freezegun) even when it gets applied before the loggers are configured.
+- `structlog.processors.TimeStamper` now works well with [_FreezeGun_](https://github.com/spulec/freezegun) even when it gets applied before the loggers are configured.
   [#364](https://github.com/hynek/structlog/pull/364)
 
-- `structlog.stdlib.ProcessorFormatter` now has a *processors* argument that allows to define a processor chain to run over *all* log entries.
+- `structlog.stdlib.ProcessorFormatter` now has a _processors_ argument that allows to define a processor chain to run over _all_ log entries.
 
   Before running the chain, two additional keys are added to the event dictionary: `_record` and `_from_structlog`.
-  With them it's possible to extract information from `logging.LogRecord`s and differentiate between *structlog* and `logging` log entries while processing them.
+  With them it's possible to extract information from `logging.LogRecord`s and differentiate between _structlog_ and `logging` log entries while processing them.
 
-  The old *processor* (singular) parameter is now deprecated, but no plans exist to remove it.
+  The old _processor_ (singular) parameter is now deprecated, but no plans exist to remove it.
   [#365](https://github.com/hynek/structlog/pull/365)
-
 
 ## [21.2.0](https://github.com/hynek/structlog/compare/21.1.0...21.2.0) - 2021-10-12
 
@@ -352,38 +322,37 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.threadlocal.get_threadlocal()` and `structlog.contextvars.get_contextvars()` can now be used to get a copy of the current thread-local/context-local context that has been bound using `structlog.threadlocal.bind_threadlocal()` and `structlog.contextvars.bind_contextvars()`.
   [#331](https://github.com/hynek/structlog/pull/331),
   [#337](https://github.com/hynek/structlog/pull/337)
-- `structlog.threadlocal.get_merged_threadlocal(bl)` and `structlog.contextvars.get_merged_contextvars(bl)` do the same, but also merge the context from a bound logger *bl*.
+- `structlog.threadlocal.get_merged_threadlocal(bl)` and `structlog.contextvars.get_merged_contextvars(bl)` do the same, but also merge the context from a bound logger _bl_.
   Same pull requests as previous change.
 - `structlog.contextvars.bind_contextvars()` now returns a mapping of keys to `contextvars.Token`s, allowing you to reset values using the new `structlog.contextvars.reset_contextvars()`.
   [#339](https://github.com/hynek/structlog/pull/339)
 - Exception rendering in `structlog.dev.ConsoleLogger` is now configurable using the `exception_formatter` setting.
-  If either the [Rich](https://github.com/Textualize/rich) or the [*better-exceptions*](https://github.com/qix-/better-exceptions) package is present, *structlog* will use them for pretty-printing tracebacks.
-  Rich takes precedence over *better-exceptions* if both are present.
+  If either the [Rich](https://github.com/Textualize/rich) or the [_better-exceptions_](https://github.com/qix-/better-exceptions) package is present, _structlog_ will use them for pretty-printing tracebacks.
+  Rich takes precedence over _better-exceptions_ if both are present.
 
   This only works if `format_exc_info` is **absent** in the processor chain.
   [#330](https://github.com/hynek/structlog/pull/330),
   [#349](https://github.com/hynek/structlog/pull/349)
+
 - The final processor can now return a `bytearray` (additionally to `str` and `bytes`).
   [#344](https://github.com/hynek/structlog/issues/344)
-
 
 ### Changed
 
 - To implement pretty exceptions (see Changes below), `structlog.dev.ConsoleRenderer` now formats exceptions itself.
 
-  Make sure to remove `format_exc_info` from your processor chain if you configure *structlog* manually.
+  Make sure to remove `format_exc_info` from your processor chain if you configure _structlog_ manually.
   This change is not really breaking, because the old use-case will keep working as before.
   However if you pass `pretty_exceptions=True` (which is the default if either `rich` or `better-exceptions` is installed), a warning will be raised and the exception will be rendered without prettification.
+
 - All use of [Colorama](https://github.com/tartley/colorama) on non-Windows systems has been excised.
   Thus, colors are now enabled by default in `structlog.dev.ConsoleRenderer` on non-Windows systems.
   You can keep using Colorama to customize colors, of course.
   [#345](https://github.com/hynek/structlog/pull/345)
 
-
 ### Fixed
 
-- *structlog* is now importable if `sys.stdout` is `None` (for example, when running using `pythonw`). [#313](https://github.com/hynek/structlog/issues/313)
-
+- _structlog_ is now importable if `sys.stdout` is `None` (for example, when running using `pythonw`). [#313](https://github.com/hynek/structlog/issues/313)
 
 ## [21.1.0](https://github.com/hynek/structlog/compare/20.2.0...21.1.0) - 2021-02-18
 
@@ -391,7 +360,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 - `structlog.dev.ConsoleRenderer` will now look for a `logger_name` key if no `logger` key is set.
   [#295](https://github.com/hynek/structlog/pull/295)
-
 
 ### Fixed
 
@@ -402,7 +370,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - The default configuration and loggers are pickleable again.
   [#301](https://github.com/hynek/structlog/pull/301)
 
-
 ## [20.2.0](https://github.com/hynek/structlog/compare/20.1.0...20.2.0) - 2020-12-31
 
 ### Removed
@@ -411,28 +378,27 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   The package meta data should ensure that you keep getting 20.1.0 on those versions.
   [#244](https://github.com/hynek/structlog/pull/244)
 
-
 ### Deprecated
 
 - Accessing the `_context` attribute of a bound logger is now deprecated.
   Please use the new `structlog.get_context()`.
 
-
 ### Added
 
-- *structlog* has now type hints for all of its APIs!
-  Since *structlog* is highly dynamic and configurable, this led to a few concessions like a specialized `structlog.stdlib.get_logger()` whose only difference to `structlog.get_logger()` is that it has the correct type hints.
+- _structlog_ has now type hints for all of its APIs!
+  Since _structlog_ is highly dynamic and configurable, this led to a few concessions like a specialized `structlog.stdlib.get_logger()` whose only difference to `structlog.get_logger()` is that it has the correct type hints.
 
   We consider them provisional for the time being – that means the backwards-compatibility does not apply to them in its full strength until we feel we got it right.
   Please feel free to provide feedback!
   [#223](https://github.com/hynek/structlog/issues/223),
   [#282](https://github.com/hynek/structlog/issues/282)
+
 - Added `structlog.make_filtering_logger` that can be used like `configure(wrapper_class=make_filtering_bound_logger(logging.INFO))`.
   It creates a highly optimized bound logger whose inactive methods only consist of a `return None`.
   This is now also the default logger.
 - As a complement, `structlog.stdlib.add_log_level()` can now additionally be imported as `structlog.processors.add_log_level` since it just adds the method name to the event dict.
 - Added `structlog.BytesLogger` to avoid unnecessary encoding round trips.
-  Concretely this is useful with *orjson* which returns bytes.
+  Concretely this is useful with _orjson_ which returns bytes.
   [#271](https://github.com/hynek/structlog/issues/271)
 - The final processor now also may return bytes that are passed untouched to the wrapped logger.
 - `structlog.get_context()` allows you to retrieve the original context of a bound logger. [#266](https://github.com/hynek/structlog/issues/266),
@@ -440,25 +406,23 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added `structlog.stdlib.AsyncBoundLogger` that executes logging calls in a thread executor and therefore doesn't block.
   [#245](https://github.com/hynek/structlog/pull/245)
 
-
 ### Changed
 
-- The default bound logger (`wrapper_class`) if you don't configure *structlog* has changed.
+- The default bound logger (`wrapper_class`) if you don't configure _structlog_ has changed.
   It's mostly compatible with the old one but a few uncommon methods like `log`, `failure`, or `err` don't exist anymore.
 
   You can regain the old behavior by using `structlog.configure(wrapper_class=structlog.BoundLogger)`.
 
   Please note that due to the various interactions between settings, it's possible that you encounter even more errors.
-  We **strongly** urge you to always configure all possible settings since the default configuration is *not* covered by our backwards-compatibility policy.
+  We **strongly** urge you to always configure all possible settings since the default configuration is _not_ covered by our backwards-compatibility policy.
+
 - `structlog.processors.add_log_level()` is now part of the default configuration.
 - `structlog.stdlib.ProcessorFormatter` no longer uses exceptions for control flow, allowing `foreign_pre_chain` processors to use `sys.exc_info()` to access the real exception.
-
 
 ### Fixed
 
 - `structlog.PrintLogger` now supports `copy.deepcopy()`.
   [#268](https://github.com/hynek/structlog/issues/268)
-
 
 ## [20.1.0](https://github.com/hynek/structlog/compare/19.2.0...20.1.0) - 2020-01-28
 
@@ -467,10 +431,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - This is the last version to support Python 2.7 (including PyPy) and 3.5.
   All following versions will only support Python 3.6 or later.
 
-
 ### Added
 
-- Added a new module `structlog.contextvars` that allows to have a global but context-local *structlog* context the same way as with `structlog.threadlocal` since 19.2.0.
+- Added a new module `structlog.contextvars` that allows to have a global but context-local _structlog_ context the same way as with `structlog.threadlocal` since 19.2.0.
   [#201](https://github.com/hynek/structlog/issues/201),
   [#236](https://github.com/hynek/structlog/pull/236)
 - Added a new module `structlog.testing` for first class testing support.
@@ -480,7 +443,6 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Added `structlog.threadlocal.unbind_threadlocal()`.
   [#239](https://github.com/hynek/structlog/pull/239)
 
-
 ### Fixed
 
 - The logger created by `structlog.get_logger()` is not detected as an abstract method anymore, when attached to an abstract base class.
@@ -489,16 +451,14 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#232](https://github.com/hynek/structlog/issues/232),
   [#242](https://github.com/hynek/structlog/pull/242)
 
-
 ## [19.2.0](https://github.com/hynek/structlog/compare/19.1.0...19.2.0) - 2019-10-16
 
 ### Removed
 
 - Python 3.4 is not supported anymore.
-It has been unsupported by the Python core team for a while now and its PyPI downloads are negligible.
+  It has been unsupported by the Python core team for a while now and its PyPI downloads are negligible.
 
-  It's very unlikely that *structlog* will break under 3.4 anytime soon, but we don't test it anymore.
-
+  It's very unlikely that _structlog_ will break under 3.4 anytime soon, but we don't test it anymore.
 
 ### Added
 
@@ -506,7 +466,7 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
 - Added more pass-through properties to `structlog.stdlib.BoundLogger`. To makes it easier to use it as a drop-in replacement for `logging.Logger`.
   [#198](https://github.com/hynek/structlog/issues/198)
 - Added new processor `structlog.dev.set_exc_info()` that will set `exc_info=True` if the method's name is `exception` and `exc_info` isn't set at all.
-  *This is only necessary when the standard library integration is not used*.
+  _This is only necessary when the standard library integration is not used_.
   It fixes the problem that in the default configuration, `structlog.get_logger().exception("hi")` in an `except` block would not print the exception without passing `exc_info=True` to it explicitly.
   [#130](https://github.com/hynek/structlog/issues/130),
   [#173](https://github.com/hynek/structlog/issues/173),
@@ -515,10 +475,8 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
 - Added a new thread-local API that allows binding values to a thread-local context explicitly without affecting the default behavior of `bind()`.
   [#222](https://github.com/hynek/structlog/issues/222),
   [#225](https://github.com/hynek/structlog/issues/225)
-- Added *pass_foreign_args* argument to `structlog.stdlib.ProcessorFormatter`. It allows to pass a foreign log record's *args* attribute to the event dictionary under the `positional_args` key.
+- Added _pass_foreign_args_ argument to `structlog.stdlib.ProcessorFormatter`. It allows to pass a foreign log record's _args_ attribute to the event dictionary under the `positional_args` key.
   [#228](https://github.com/hynek/structlog/issues/228)
-
-
 
 ### Changed
 
@@ -527,20 +485,18 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
   [#219](https://github.com/hynek/structlog/issues/219)
 - `structlog.dev.ConsoleRenderer` now calls `str()` on the event value. [#221](https://github.com/hynek/structlog/issues/221)
 
-
 ### Fixed
 
 - `structlog.dev.ConsoleRenderer` now uses no colors by default, if Colorama is not available.
   [#215](https://github.com/hynek/structlog/issues/215)
-- `structlog.dev.ConsoleRenderer` now initializes Colorama lazily, to prevent accidental side-effects just by importing *structlog*.
+- `structlog.dev.ConsoleRenderer` now initializes Colorama lazily, to prevent accidental side-effects just by importing _structlog_.
   [#210](https://github.com/hynek/structlog/issues/210)
-- A best effort has been made to make as much of *structlog* pickleable as possible to make it friendlier with `multiprocessing` and similar libraries.
+- A best effort has been made to make as much of _structlog_ pickleable as possible to make it friendlier with `multiprocessing` and similar libraries.
   Some classes can only be pickled on Python 3 or using the [dill](https://pypi.org/project/dill/) library though and that is very unlikely to change.
 
   So far, the configuration proxy, `structlog.processor.TimeStamper`, `structlog.BoundLogger`, `structlog.PrintLogger` and `structlog.dev.ConsoleRenderer` have been made pickleable.
   Please report if you need any another class fixed.
   [#126](https://github.com/hynek/structlog/issues/126)
-
 
 ## [19.1.0](https://github.com/hynek/structlog/compare/18.2.0...19.1.0) - 2019-02-02
 
@@ -549,16 +505,14 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
 - `structlog.ReturnLogger` and `structlog.PrintLogger` now have a `fatal()` log method.
   [#181](https://github.com/hynek/structlog/issues/181)
 
-
 ### Changed
 
 - As announced in 18.1.0, `pip install -e .[dev]` now installs all development dependencies.
   Sorry for the inconveniences this undoubtedly will cause!
-- *structlog* now tolerates passing through `dict`s to stdlib logging.
+- _structlog_ now tolerates passing through `dict`s to stdlib logging.
   [#187](https://github.com/hynek/structlog/issues/187),
   [#188](https://github.com/hynek/structlog/pull/188),
   [#189](https://github.com/hynek/structlog/pull/189)
-
 
 ### Fixed
 
@@ -566,40 +520,36 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
   A workaround has been added.
   [#174](https://github.com/hynek/structlog/issues/174)
 
-
 ## [18.2.0](https://github.com/hynek/structlog/compare/18.1.0...18.2.0) - 2018-09-05
 
 ### Added
 
-- Added `structlog.stdlib.add_log_level_number()` processor that adds the level *number* to the event dictionary.
+- Added `structlog.stdlib.add_log_level_number()` processor that adds the level _number_ to the event dictionary.
   Can be used to simplify log filtering.
   [#151](https://github.com/hynek/structlog/pull/151)
-- `structlog.processors.JSONRenderer` now allows for overwriting the *default* argument of its serializer.
+- `structlog.processors.JSONRenderer` now allows for overwriting the _default_ argument of its serializer.
   [#77](https://github.com/hynek/structlog/pull/77),
   [#163](https://github.com/hynek/structlog/pull/163)
 - Added `try_unbind()` that works like `unbind()` but doesn't raise a `KeyError` if one of the keys is missing.
   [#171](https://github.com/hynek/structlog/pull/171)
 
-
 ## [18.1.0](https://github.com/hynek/structlog/compare/17.2.0...18.1.0) - 2018-01-27
 
 ### Deprecated
 
-- The meaning of the `structlog[dev]` installation target will change from "colorful output" to "dependencies to develop *structlog*" in 19.1.0.
+- The meaning of the `structlog[dev]` installation target will change from "colorful output" to "dependencies to develop _structlog_" in 19.1.0.
 
-  The main reason behind this decision is that it's impossible to have a *structlog* in your normal dependencies and additionally a `structlog[dev]` for development (`pip` will report an error).
-
+  The main reason behind this decision is that it's impossible to have a _structlog_ in your normal dependencies and additionally a `structlog[dev]` for development (`pip` will report an error).
 
 ### Added
 
-- `structlog.dev.ConsoleRenderer` now accepts a *force_colors* argument to output colored logs even if the destination is not a tty.
+- `structlog.dev.ConsoleRenderer` now accepts a _force_colors_ argument to output colored logs even if the destination is not a tty.
   Use this option if your logs are stored in files that are intended to be streamed to the console.
-- `structlog.dev.ConsoleRenderer` now accepts a *level_styles* argument for overriding the colors for individual levels, as well as to add new levels.
+- `structlog.dev.ConsoleRenderer` now accepts a _level_styles_ argument for overriding the colors for individual levels, as well as to add new levels.
   See the docs for `ConsoleRenderer.get_default_level_styles()` for usage.
   [#139](https://github.com/hynek/structlog/pull/139)
-- Added `structlog.is_configured()` to check whether or not *structlog* has been configured.
+- Added `structlog.is_configured()` to check whether or not _structlog_ has been configured.
 - Added `structlog.get_config()` to introspect current configuration.
-
 
 ### Changed
 
@@ -608,22 +558,21 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
 - `structlog.stdlib.BoundLogger.exception()` now uses the `exc_info` argument if it has been passed instead of setting it unconditionally to `True`. [#149](https://github.com/hynek/structlog/pull/149)
 - Default configuration now uses plain `dict`s on Python 3.6+ and PyPy since they are ordered by default.
 
-
 ### Fixed
+
 - Do not encapsulate Twisted failures twice with newer versions of Twisted.
   [#144](https://github.com/hynek/structlog/issues/144)
-
 
 ## [17.2.0](https://github.com/hynek/structlog/compare/17.1.0...17.2.0) - 2017-05-15
 
 ### Added
 
-- `structlog.stdlib.ProcessorFormatter` now accepts *keep_exc_info* and *keep_stack_info* arguments to control what to do with this information on log records.
+- `structlog.stdlib.ProcessorFormatter` now accepts _keep_exc_info_ and _keep_stack_info_ arguments to control what to do with this information on log records.
   Most likely you want them both to be `False` therefore it's the default.
   [#109](https://github.com/hynek/structlog/issues/109)
 
-
 ### Fixed
+
 - `structlog.stdlib.add_logger_name()` now works in `structlog.stdlib.ProcessorFormatter`'s `foreign_pre_chain`.
   [#112](https://github.com/hynek/structlog/issues/112)
 - Clear log record args in `structlog.stdlib.ProcessorFormatter` after rendering.
@@ -631,46 +580,41 @@ It has been unsupported by the Python core team for a while now and its PyPI dow
   [#116](https://github.com/hynek/structlog/issues/116),
   [#117](https://github.com/hynek/structlog/issues/117)
 
-
 ## [17.1.0](https://github.com/hynek/structlog/compare/16.1.0...17.1.0) - 2017-04-24
 
 The main features of this release are massive improvements in standard library's `logging` integration.
 Have a look at the updated [standard library chapter](https://www.structlog.org/en/stable/standard-library.html) on how to use them!
 Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilbert Gilb's](https://github.com/gilbsgilbs), [Iva Kaneva](https://github.com/if-fi), [insolite](https://github.com/insolite), and [sky-code](https://github.com/sky-code), that made them possible.
 
-
 ### Added
 
 - Added `structlog.stdlib.render_to_log_kwargs()`.
   This allows you to use `logging`-based formatters to take care of rendering your entries.
   [#98](https://github.com/hynek/structlog/issues/98)
-- Added `structlog.stdlib.ProcessorFormatter` which does the opposite: This allows you to run *structlog* processors on arbitrary `logging.LogRecords`.
+- Added `structlog.stdlib.ProcessorFormatter` which does the opposite: This allows you to run _structlog_ processors on arbitrary `logging.LogRecords`.
   [#79](https://github.com/hynek/structlog/issues/79),
   [#105](https://github.com/hynek/structlog/issues/105)
-- Added *repr_native_str* to `structlog.processors.KeyValueRenderer` and `structlog.dev.ConsoleRenderer`.
+- Added _repr_native_str_ to `structlog.processors.KeyValueRenderer` and `structlog.dev.ConsoleRenderer`.
   This allows for human-readable non-ASCII output on Python 2 (`repr()` on Python 2 behaves like `ascii()` on Python 3 in that regard).
   As per compatibility policy, it's on (original behavior) in `KeyValueRenderer` and off (human-friendly behavior) in `ConsoleRenderer`.
   [#94](https://github.com/hynek/structlog/issues/94)
-- Added *colors* argument to `structlog.dev.ConsoleRenderer` and made it the default renderer.
+- Added _colors_ argument to `structlog.dev.ConsoleRenderer` and made it the default renderer.
   [#78](https://github.com/hynek/structlog/pull/78)
-
 
 ### Changed
 
-- The default renderer now is `structlog.dev.ConsoleRenderer` if you don't configure *structlog*.
+- The default renderer now is `structlog.dev.ConsoleRenderer` if you don't configure _structlog_.
   Colors are used if available and human-friendly timestamps are prepended.
   This is in line with our backwards-compatibility policy that explicitly excludes default settings.
 - UNIX epoch timestamps from `structlog.processors.TimeStamper` are more precise now.
 - Positional arguments are now removed even if they are empty.
   [#82](https://github.com/hynek/structlog/pull/82)
 
-
 ## Fixed
 
 - Fixed bug with Python 3 and `structlog.stdlib.BoundLogger.log()`.
   Error log level was not reproducible and was logged as exception one time out of two.
   [#92](https://github.com/hynek/structlog/pull/92)
-
 
 ## [16.1.0](https://github.com/hynek/structlog/compare/16.0.0...16.1.0) - 2016-05-24
 
@@ -684,13 +628,11 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 
   Python 3.3 never had a significant user base and wasn't part of any distribution's LTS release.
 
-
 ### Added
 
 - Added a `drop_missing` argument to `KeyValueRenderer`.
   If `key_order` is used and a key is missing a value, it's not rendered at all instead of being rendered as `None`.
   [#67](https://github.com/hynek/structlog/pull/67)
-
 
 ### Fixed
 
@@ -698,7 +640,6 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Don't cache loggers in lazy proxies returned from `get_logger()`.
   This lead to in-place mutation of them if used before configuration which in turn lead to the problem that configuration was applied only partially to them later.
   [#72](https://github.com/hynek/structlog/pull/72)
-
 
 ## [16.0.0](https://github.com/hynek/structlog/compare/15.3.0...16.0.0) - 2016-01-28
 
@@ -708,12 +649,10 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added `structlog.processors.UnicodeDecoder` that will decode all byte string values in an event dictionary to Unicode.
 - Added `serializer` parameter to `structlog.processors.JSONRenderer` which allows for using different (possibly faster) JSON encoders than the standard library.
 
-
 ### Changed
 
 - `structlog.processors.ExceptionPrettyPrinter` and `structlog.processors.format_exc_info` now support passing of Exceptions on Python 3.
-- [*six*](https://six.readthedocs.io/) is now used for compatibility.
-
+- [_six_](https://six.readthedocs.io/) is now used for compatibility.
 
 ### Fixed
 
@@ -722,7 +661,6 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Be more more lenient about missing `__name__`s.
   [#62](https://github.com/hynek/structlog/pull/62)
 
-
 ## [15.3.0](https://github.com/hynek/structlog/compare/15.2.0...15.3.0) - 2015-09-25
 
 ### Added
@@ -730,12 +668,10 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Officially support Python 3.5.
 - Added `structlog.ReturnLogger.failure` and `structlog.PrintLogger.failure` as preparation for the new Twisted logging system.
 
-
 ### Fixed
 
 - Tolerate frames without a `__name__`, better.
   [#58](https://github.com/hynek/structlog/pull/58)
-
 
 ## [15.2.0](https://github.com/hynek/structlog/compare/15.1.0...15.2.0) - 2015-06-10
 
@@ -744,27 +680,23 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added option to specify target key in `structlog.processors.TimeStamper` processor.
   [#51](https://github.com/hynek/structlog/pull/51)
 
-
 ### Changed
 
 - Allow empty lists of processors.
   This is a valid use case since [#26](https://github.com/hynek/structlog/issues/26) has been merged.
   Before, supplying an empty list resulted in the defaults being used.
-- Better support of `logging.Logger.exception` within *structlog*.
+- Better support of `logging.Logger.exception` within _structlog_.
   [#52](https://github.com/hynek/structlog/pull/52)
-
 
 ### Fixed
 
 - Prevent Twisted's `log.err` from quoting strings rendered by `structlog.twisted.JSONRenderer`.
-
 
 ## [15.1.0](https://github.com/hynek/structlog/compare/15.0.0...15.1.0) - 2015-02-24
 
 ### Fixed
 
 - Tolerate frames without a `__name__` when guessing callsite names.
-
 
 ## [15.0.0](https://github.com/hynek/structlog/compare/0.4.2...15.0.0) - 2015-01-23
 
@@ -777,15 +709,13 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Added `structlog.stdlib.BoundLogger.exception`.
   [#22](https://github.com/hynek/structlog/pull/22)
 
-
 ### Changed
 
 - Pass positional arguments to stdlib wrapped loggers that use string formatting.
   [#19](https://github.com/hynek/structlog/pull/19)
-- *structlog* is now dually licensed under the [Apache License, Version 2](https://choosealicense.com/licenses/apache/) and the [MIT](https://choosealicense.com/licenses/mit/) license.
-  Therefore it is now legal to use *structlog* with [GPLv2](https://choosealicense.com/licenses/gpl-2.0/)-licensed projects.
+- _structlog_ is now dually licensed under the [Apache License, Version 2](https://choosealicense.com/licenses/apache/) and the [MIT](https://choosealicense.com/licenses/mit/) license.
+  Therefore it is now legal to use _structlog_ with [GPLv2](https://choosealicense.com/licenses/gpl-2.0/)-licensed projects.
   [#28](https://github.com/hynek/structlog/pull/28)
-
 
 ## [0.4.2](https://github.com/hynek/structlog/compare/0.4.1...0.4.2) - 2014-07-26
 
@@ -795,7 +725,6 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   There is no justification to add complexity for a Python version that nobody uses.
   If you are one of the [0.350%](https://alexgaynor.net/2014/jan/03/pypi-download-statistics/) that use Python 3.2, please stick to the 0.4 branch; critical bugs will still be fixed.
 
-
 ### Added
 
 - Officially support Python 3.4.
@@ -803,7 +732,6 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   See the adapting chapter.
   [#26](https://github.com/hynek/structlog/issues/26)
 - Test Twisted-related code on Python 3 (with some caveats).
-
 
 ### Fixed
 
@@ -813,18 +741,15 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - `structlog.PrintLogger` now is thread-safe.
 - `from structlog import *` works now (but you still shouldn't use it).
 
-
 ## [0.4.1](https://github.com/hynek/structlog/compare/0.4.0...0.4.1) - 2013-12-19
 
 ### Changed
 
 - Don't cache proxied methods in `structlog.threadlocal._ThreadLocalDictWrapper`. This doesn't affect regular users.
 
-
 ### Fixed
 
 - Various doc fixes.
-
 
 ## [0.4.0](https://github.com/hynek/structlog/compare/0.3.2...0.4.0) - 2013-11-10
 
@@ -841,20 +766,17 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
   This is useful together with frameworks.
 - Add meta data (for example, function names, line numbers) extraction for wrapped stdlib loggers. [#5](https://github.com/hynek/structlog/pull/5)
 
-
 ## [0.3.2](https://github.com/hynek/structlog/compare/0.3.1...0.3.2) - 2013-09-27
 
 ### Fixed
 
 - Fix stdlib's name guessing.
 
-
 ## [0.3.1](https://github.com/hynek/structlog/compare/0.3.0...0.3.1) - 2013-09-26
 
 ### Fixed
 
 - Added forgotten `structlog.processors.TimeStamper` to API documentation.
-
 
 ## [0.3.0](https://github.com/hynek/structlog/compare/0.2.0...0.3.0) - 2013-09-23
 
@@ -871,7 +793,6 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Extract a common base class for loggers that does nothing except keeping the context state.
   This makes writing custom loggers much easier and more straight-forward. See `structlog.BoundLoggerBase`.
 
-
 ## [0.2.0](https://github.com/hynek/structlog/compare/0.1.0...0.2.0) - 2013-09-17
 
 ### Added
@@ -880,12 +801,10 @@ Special thanks go to [Fabian Büchler](https://github.com/fabianbuechler), [Gilb
 - Enhance Twisted support by offering JSONification of non-structlog log entries.
 - Allow for custom serialization in `structlog.twisted.JSONRenderer` without abusing `__repr__`.
 
-
 ### Changed
 
 - Promote to stable, thus henceforth a strict backwards-compatibility policy is put into effect.
 - `structlog.PrintLogger` now uses proper I/O routines and is thus viable not only for examples but also for production.
-
 
 ## [0.1.0](https://github.com/hynek/structlog/tree/0.1.0) - 2013-09-16
 

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -36,7 +36,9 @@ NAME_TO_LEVEL = {
 }
 
 LEVEL_TO_NAME = {
-    v: k for k, v in NAME_TO_LEVEL.items() if k not in ("warn", "exception", "notset")
+    v: k
+    for k, v in NAME_TO_LEVEL.items()
+    if k not in ("warn", "exception", "notset")
 }
 
 # Keep around for backwards-compatability in case someone imported them.

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -36,14 +36,20 @@ NAME_TO_LEVEL = {
 }
 
 LEVEL_TO_NAME = {
-    v: k
-    for k, v in NAME_TO_LEVEL.items()
-    if k not in ("warn", "exception", "notset")
+    v: k for k, v in NAME_TO_LEVEL.items() if k not in ("warn", "exception", "notset")
 }
 
 # Keep around for backwards-compatability in case someone imported them.
 _LEVEL_TO_NAME = LEVEL_TO_NAME
 _NAME_TO_LEVEL = NAME_TO_LEVEL
+
+
+def map_method_name(method_name: str) -> str:
+    if method_name == "warn":
+        return "warning"
+    if method_name == "exception":
+        return "error"
+    return method_name
 
 
 def add_log_level(
@@ -63,13 +69,7 @@ def add_log_level(
     .. versionchanged:: 24.1.0
        Added mapping from "exception" to "error"
     """
-    if method_name == "warn":
-        # The stdlib has an alias
-        method_name = "warning"
-    elif method_name == "exception":
-        # exception("") method is the same as error("", exc_info=True)
-        method_name = "error"
 
-    event_dict["level"] = method_name
+    event_dict["level"] = map_method_name(method_name)
 
     return event_dict

--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -47,10 +47,14 @@ _NAME_TO_LEVEL = NAME_TO_LEVEL
 
 
 def map_method_name(method_name: str) -> str:
+    # warn is just a deprecated alias in the stdlib.
     if method_name == "warn":
         return "warning"
+
+    # Calling exception("") is the same as error("", exc_info=True)
     if method_name == "exception":
         return "error"
+
     return method_name
 
 

--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from typing import Any, Generator, NamedTuple, NoReturn
 
 from ._config import configure, get_config
+from ._log_levels import map_method_name
 from .exceptions import DropEvent
 from .typing import EventDict, WrappedLogger
 
@@ -51,7 +52,7 @@ class LogCapture:
     def __call__(
         self, _: WrappedLogger, method_name: str, event_dict: EventDict
     ) -> NoReturn:
-        event_dict["log_level"] = method_name
+        event_dict["log_level"] = map_method_name(method_name)
         self.entries.append(event_dict)
 
         raise DropEvent

--- a/src/structlog/testing.py
+++ b/src/structlog/testing.py
@@ -42,6 +42,10 @@ class LogCapture:
     :ivar List[structlog.typing.EventDict] entries: The captured log entries.
 
     .. versionadded:: 20.1.0
+
+    .. versionchanged:: 24.3.0
+       Added mapping from "exception" to "error"
+       Added mapping from "warn" to "warning"
     """
 
     entries: list[EventDict]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -5,6 +5,8 @@
 
 import pytest
 
+import structlog
+
 from structlog import get_config, get_logger, testing
 from structlog.testing import (
     CapturedCall,
@@ -82,6 +84,29 @@ class TestCaptureLogs:
                 "answer": 42,
                 "foo": "bar",
                 "log_level": "info",
+            }
+        ]
+
+    def test_captures_log_level_mapping(self):
+        """
+        Log level mapping is captured.
+        """
+        structlog.configure(
+            processors=[
+                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            ],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+        )
+        with testing.capture_logs() as logs:
+            get_logger().exception("hello", answer=42)
+
+        assert logs == [
+            {
+                "event": "hello",
+                "answer": 42,
+                "exc_info": True,
+                "log_level": "error",
             }
         ]
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -89,7 +89,7 @@ class TestCaptureLogs:
 
     def test_captures_log_level_mapping(self):
         """
-        Log level mapping is captured.
+        exceptions and warn log levels are mapped like in regular loggers.
         """
         structlog.configure(
             processors=[
@@ -100,15 +100,21 @@ class TestCaptureLogs:
         )
         with testing.capture_logs() as logs:
             get_logger().exception("hello", answer=42)
+            get_logger().warn("again", answer=23)
 
-        assert logs == [
+        assert [
             {
                 "event": "hello",
                 "answer": 42,
                 "exc_info": True,
                 "log_level": "error",
-            }
-        ]
+            },
+            {
+                "answer": 23,
+                "event": "again",
+                "log_level": "warning",
+            },
+        ] == logs
 
 
 class TestReturnLogger:


### PR DESCRIPTION
# Summary

The fix of mapping exception to error log level doesn't work in capture_log during test

See https://github.com/hynek/structlog/issues/584#issuecomment-2150290095
