### PR TITLE
Make BindableLogger return Self on binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.4.0...HEAD)
 
+## Changed
+
+- `structlog.typing.BindableLogger` protocol now returns `Self` instead of `BindableLogger`.
+  This adds a dependency on [*typing-extensions*](https://pypi.org/project/typing-extensions/) for Pythons older than 3.11.
+
+  [#642](https://github.com/hynek/structlog/pull/642)
+
 
 ## [24.4.0](https://github.com/hynek/structlog/compare/24.3.0...24.4.0) - 2024-07-17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: System :: Logging",
     "Typing :: Typed",
 ]
-dependencies = []
+dependencies = ["typing-extensions; python_version<'3.11'"]
 
 [project.urls]
 Documentation = "https://www.structlog.org/"

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -152,7 +152,7 @@ def tmp_bind(
 
     saved = as_immutable(logger)._context
     try:
-        yield logger.bind(**tmp_values)  # type: ignore[misc]
+        yield logger.bind(**tmp_values)
     finally:
         logger._context.clear()
         logger._context.update(saved)

--- a/src/structlog/typing.py
+++ b/src/structlog/typing.py
@@ -14,6 +14,8 @@ probably change to something more elegant.
 
 from __future__ import annotations
 
+import sys
+
 from types import TracebackType
 from typing import (
     Any,
@@ -29,6 +31,12 @@ from typing import (
     Union,
     runtime_checkable,
 )
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 WrappedLogger = Any
@@ -130,13 +138,13 @@ class BindableLogger(Protocol):
 
     _context: Context
 
-    def bind(self, **new_values: Any) -> BindableLogger: ...
+    def bind(self, **new_values: Any) -> Self: ...
 
-    def unbind(self, *keys: str) -> BindableLogger: ...
+    def unbind(self, *keys: str) -> Self: ...
 
-    def try_unbind(self, *keys: str) -> BindableLogger: ...
+    def try_unbind(self, *keys: str) -> Self: ...
 
-    def new(self, **new_values: Any) -> BindableLogger: ...
+    def new(self, **new_values: Any) -> Self: ...
 
 
 class FilteringBoundLogger(BindableLogger, Protocol):


### PR DESCRIPTION
As a nice demonstration of its purpose, it removes one `type: ignore` from our own code base.

Fixes #641