### PR TITLE
handle missing exc_info in ExceptionDictTransformer

### DIFF
--- a/src/structlog/_frames.py
+++ b/src/structlog/_frames.py
@@ -15,6 +15,12 @@ from typing import Callable
 from .contextvars import _ASYNC_CALLING_STACK
 from .typing import ExcInfo
 
+def is_missing_exc_info(exc_info: ExcInfo) -> bool:
+    """
+    Return True if exc_info is the missing value.
+    """
+    return exc_info == (None, None, None)  # type: ignore[comparison-overlap]
+
 
 def _format_exception(exc_info: ExcInfo) -> str:
     """
@@ -22,7 +28,7 @@ def _format_exception(exc_info: ExcInfo) -> str:
 
     Shamelessly stolen from stdlib's logging module.
     """
-    if exc_info == (None, None, None):  # type: ignore[comparison-overlap]
+    if is_missing_exc_info(exc_info):
         return "MISSING"
 
     sio = StringIO()

--- a/src/structlog/_frames.py
+++ b/src/structlog/_frames.py
@@ -15,6 +15,7 @@ from typing import Callable
 from .contextvars import _ASYNC_CALLING_STACK
 from .typing import ExcInfo
 
+
 def is_missing_exc_info(exc_info: ExcInfo) -> bool:
     """
     Return True if exc_info is the missing value.

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -24,6 +24,7 @@ from typing import Any, Iterable, Sequence, Tuple, Union
 
 from ._frames import is_missing_exc_info
 
+
 try:
     import rich
     import rich.pretty

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -22,6 +22,7 @@ from traceback import walk_tb
 from types import ModuleType, TracebackType
 from typing import Any, Iterable, Sequence, Tuple, Union
 
+from ._frames import is_missing_exc_info
 
 try:
     import rich
@@ -412,6 +413,8 @@ class ExceptionDictTransformer:
         self.use_rich = use_rich
 
     def __call__(self, exc_info: ExcInfo) -> list[dict[str, Any]]:
+        if is_missing_exc_info(exc_info):
+            return []
         trace = extract(
             *exc_info,
             show_locals=self.show_locals,

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -737,7 +737,7 @@ def test_exception_dict_transformer_missing_exc_info():
     ExceptionDictTransformer returns an empty list if exc_info is missing.
     """
     transformer = tracebacks.ExceptionDictTransformer()
-    
+
     result = transformer(exc_info=(None, None, None))
-    
+
     assert [] == result

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -737,5 +737,7 @@ def test_exception_dict_transformer_missing_exc_info():
     ExceptionDictTransformer returns an empty list if exc_info is missing.
     """
     transformer = tracebacks.ExceptionDictTransformer()
+    
     result = transformer(exc_info=(None, None, None))
-    assert result == []
+    
+    assert [] == result

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -730,3 +730,12 @@ def test_json_traceback_value_error(
         monkeypatch.setattr(kwargs["suppress"][0], "__file__", None)
     with pytest.raises(ValueError, match=next(iter(kwargs.keys()))):
         tracebacks.ExceptionDictTransformer(**kwargs)
+
+
+def test_exception_dict_transformer_missing_exc_info():
+    """
+    ExceptionDictTransformer returns an empty list if exc_info is missing.
+    """
+    transformer = tracebacks.ExceptionDictTransformer()
+    result = transformer(exc_info=(None, None, None))
+    assert result == []


### PR DESCRIPTION
- Added a new utility function is_missing_exc_info to check if exc_info is missing.
- Updated ExceptionDictTransformer to return an empty list when exc_info is missing.
- Modified _format_exception to use the new is_missing_exc_info function.
- Added a test case to verify that ExceptionDictTransformer returns an empty list when exc_info is missing.

https://github.com/hynek/structlog/issues/656

# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
