### PR TITLE
Switch base methods to return Self instead of BoundLoggerBase

### DIFF
--- a/src/structlog/_base.py
+++ b/src/structlog/_base.py
@@ -9,7 +9,8 @@ Logger wrapper and helper class.
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, Self
+from typing_extensions import Self
 
 from structlog.exceptions import DropEvent
 
@@ -62,7 +63,7 @@ class BoundLoggerBase:
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def bind(self, **new_values: Any) -> BoundLoggerBase:
+    def bind(self, **new_values: Any) -> Self:
         """
         Return a new logger with *new_values* added to the existing ones.
         """
@@ -72,7 +73,7 @@ class BoundLoggerBase:
             self._context.__class__(self._context, **new_values),
         )
 
-    def unbind(self, *keys: str) -> BoundLoggerBase:
+    def unbind(self, *keys: str) -> Self:
         """
         Return a new logger with *keys* removed from the context.
 
@@ -85,7 +86,7 @@ class BoundLoggerBase:
 
         return bl
 
-    def try_unbind(self, *keys: str) -> BoundLoggerBase:
+    def try_unbind(self, *keys: str) -> Self:
         """
         Like :meth:`unbind`, but best effort: missing keys are ignored.
 
@@ -97,7 +98,7 @@ class BoundLoggerBase:
 
         return bl
 
-    def new(self, **new_values: Any) -> BoundLoggerBase:
+    def new(self, **new_values: Any) -> Self:
         """
         Clear context and binds *new_values* using `bind`.
 


### PR DESCRIPTION
# Summary
<!-- Please tell us what your pull request is about here. -->
This Pull Request switches several `BoundLoggerBase` methods to annotate a return type of `typing_extensions.Self` instead of `BoundLoggerBase`. This change is consistent with the code which [returns specifically](https://github.com/hynek/structlog/blob/main/src/structlog/_base.py#L70) `self.__class__()` and with the tests that ensure the [type is preserved when `.bind()` is called](https://github.com/hynek/structlog/blob/main/tests/test_base.py#L82).

This should not have any runtime changes, but instead fixes a typing bug which caused the following code to incorrectly fail type-checking:
```python
from structlog import get_logger, BoundLogger

log: BoundLogger = get_logger()
log.info("This is OK")
log = log.bind() #  error: Type "BoundLoggerBase" is not assignable to declared type "BoundLogger"
log.info("This should also be okay")
```

Before this change:
![Screenshot 2024-10-03 at 4 48 17 PM](https://github.com/user-attachments/assets/5c1fa18f-76a7-466f-89d7-d451475bb943)

After this change:
![Screenshot 2024-10-03 at 4 48 54 PM](https://github.com/user-attachments/assets/f411aa7d-bbcf-41cc-9a77-edcf6b0ac264)

# Pull Request Check List
It does not appear to me that any of these apply, but I am happy to make any necessary changes to the PR or do any upkeep tasks 
<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [ ] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
