### PR TITLE
Test false utc formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 <!-- changelog follows -->
 
+## [Unreleased](https://github.com/hynek/structlog/compare/hynek:structlog:main...python-mutation-testing:structlog:test-false-utc-formatting)
+
+### Added
+- Add the `tests.test_renderers.test_false_utc` test to test the effect of false value of the `utc` parameter on time formatting in the `MaybeTimeStamper` class.
+
+  [#661](https://github.com/hynek/structlog/issues/661)
+
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/24.4.0...HEAD)
 

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -495,7 +495,7 @@ class TestMaybeTimeStamper:
         try:
             datetime.datetime.strptime(timestamp, expected_format)
         except ValueError:
-            pytest.fail(f"Timestamp does not match expected format")
+            pytest.fail("Timestamp does not match expected format")
 
 
 class TestFormatExcInfo:

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -482,6 +482,21 @@ class TestMaybeTimeStamper:
 
         assert "timestamp" in mts(None, None, {})
 
+    def test_false_utc(self):
+        """
+        If utc is False, the formatter should return a timestamp in local time.
+        """
+        mts = MaybeTimeStamper(utc=False, fmt="iso")
+        expected_format = '%Y-%m-%dT%H:%M:%S.%f'
+
+        assert "timestamp" in mts(None, None, {})
+        timestamp = mts(None, None, {})["timestamp"]
+
+        try:
+            datetime.datetime.strptime(timestamp, expected_format)
+        except ValueError:
+            assert False, "Timestamp does not match the expected format"
+
 
 class TestFormatExcInfo:
     def test_custom_formatter(self):

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -493,7 +493,9 @@ class TestMaybeTimeStamper:
         timestamp = mts(None, None, {})["timestamp"]
 
         try:
-            datetime.datetime.strptime(timestamp, expected_format)
+            datetime.datetime.strptime(timestamp, expected_format).replace(
+                tzinfo=datetime.timezone.utc
+            )
         except ValueError:
             pytest.fail("Timestamp does not match expected format")
 

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -487,7 +487,7 @@ class TestMaybeTimeStamper:
         If utc is False, the formatter should return a timestamp in local time.
         """
         mts = MaybeTimeStamper(utc=False, fmt="iso")
-        expected_format = '%Y-%m-%dT%H:%M:%S.%f'
+        expected_format = "%Y-%m-%dT%H:%M:%S.%f"
 
         assert "timestamp" in mts(None, None, {})
         timestamp = mts(None, None, {})["timestamp"]

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -495,7 +495,7 @@ class TestMaybeTimeStamper:
         try:
             datetime.datetime.strptime(timestamp, expected_format)
         except ValueError:
-            assert False, "Timestamp does not match the expected format"
+            pytest.fail(f"Timestamp does not match expected format")
 
 
 class TestFormatExcInfo:


### PR DESCRIPTION
# Summary

This is a test case to test the functionality of MaybeTimeStamper in cases where the UTC argument is false and the formatting is affected by that.
This closes #661. 


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
