### PR TITLE
Introducing structlog Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
    <a href="https://doi.org/10.5281/zenodo.7353739"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.7353739.svg" alt="DOI"></a>
    <a href="https://pypi.org/project/structlog/"><img src="https://img.shields.io/pypi/pyversions/structlog.svg" alt="Supported Python versions of the current PyPI release." /></a>
    <a href="https://pepy.tech/project/structlog"><img src="https://static.pepy.tech/personalized-badge/structlog?period=month&units=international_system&left_color=grey&right_color=blue&left_text=Downloads%20/%20Month" alt="Downloads per month" /></a>
+   <a href="https://gurubase.io/g/structlog"><img src="https://img.shields.io/badge/Gurubase-Ask%20structlog%20Guru-006BFF" alt="Gurubase"></a>
 </p>
 
 <p align="center"><em>Simple. Powerful. Fast. Pick three.</em></p>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [structlog Guru](https://gurubase.io/g/structlog) to Gurubase. structlog Guru uses the data from this repo and data from the [docs](https://www.structlog.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "structlog Guru", which highlights that structlog now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable structlog Guru in Gurubase, just let me know that's totally fine.
