### PR TITLE
TimeStamper() now uses TZ-aware objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.stdlib.BoundLogger`'s binding-related methods now also return `Self`.
   [#694](https://github.com/hynek/structlog/pull/694)
 
+- `structlog.processors.TimeStamper` now produces internally timezone-aware `datetime` objects.
+  Default output hasn't changed, but you can now use `%z` in your *fmt* string.
+  [#709](https://github.com/hynek/structlog/pull/709)
+
 
 ### Fixed
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -541,7 +541,7 @@ def _make_stamper(
         def stamper_iso_local(event_dict: EventDict) -> EventDict:
             # We remove the timezone offset for backwards-compatibility. If the
             # user wants a timezone, they have to set fmt manually.
-            event_dict[key] = now().isoformat().rsplit("+", 1)[0]
+            event_dict[key] = now().isoformat()[:-6]
             return event_dict
 
         def stamper_iso_utc(event_dict: EventDict) -> EventDict:

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -525,8 +525,7 @@ def _make_stamper(
     else:
 
         def now() -> datetime.datetime:
-            # A naive local datetime is fine here, because we only format it.
-            return datetime.datetime.now()  # noqa: DTZ005
+            return datetime.datetime.now().astimezone()
 
     if fmt is None:
 
@@ -540,7 +539,9 @@ def _make_stamper(
     if fmt.upper() == "ISO":
 
         def stamper_iso_local(event_dict: EventDict) -> EventDict:
-            event_dict[key] = now().isoformat()
+            # We remove the timezone offset for backwards-compatibility. If the
+            # user wants a timezone, they have to set fmt manually.
+            event_dict[key] = now().isoformat().rsplit("+", 1)[0]
             return event_dict
 
         def stamper_iso_utc(event_dict: EventDict) -> EventDict:

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -525,7 +525,9 @@ def _make_stamper(
     else:
 
         def now() -> datetime.datetime:
-            return datetime.datetime.now().astimezone()
+            # We don't need the TZ for our own formatting. We add it only for
+            # user-defined formats later.
+            return datetime.datetime.now()  # noqa: DTZ005
 
     if fmt is None:
 
@@ -539,9 +541,7 @@ def _make_stamper(
     if fmt.upper() == "ISO":
 
         def stamper_iso_local(event_dict: EventDict) -> EventDict:
-            # We remove the timezone offset for backwards-compatibility. If the
-            # user wants a timezone, they have to set fmt manually.
-            event_dict[key] = now().isoformat()[:-6]
+            event_dict[key] = now().isoformat()
             return event_dict
 
         def stamper_iso_utc(event_dict: EventDict) -> EventDict:
@@ -554,7 +554,7 @@ def _make_stamper(
         return stamper_iso_local
 
     def stamper_fmt(event_dict: EventDict) -> EventDict:
-        event_dict[key] = now().strftime(fmt)
+        event_dict[key] = now().astimezone().strftime(fmt)
 
         return event_dict
 

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -396,8 +396,8 @@ class TestTimeStamper:
     @freeze_time("1980-03-25 16:00:00")
     def test_local(self):
         """
-        Timestamp in local timezone work.  We can't add a timezone to the
-        string without additional libraries.
+        Timestamp in local timezone work. Due to historic reasons, the default
+        format does not include a timezone.
         """
         ts = TimeStamper(fmt="iso", utc=False)
         d = ts(None, None, {})
@@ -413,6 +413,17 @@ class TestTimeStamper:
         d = ts(None, None, {})
 
         assert "1980" == d["timestamp"]
+
+    @freeze_time("1980-03-25 16:00:00")
+    def test_tz_aware(self):
+        """
+        The timestamp that is used for formatting is timezone-aware.
+        """
+        ts = TimeStamper(fmt="%z")
+        d = ts(None, None, {})
+
+        assert "" == datetime.datetime.now().strftime("%z")  # noqa: DTZ005
+        assert "" != d["timestamp"]
 
     @freeze_time("1980-03-25 16:00:00")
     def test_adds_Z_to_iso(self):


### PR DESCRIPTION
The default output doesn't change but manual formatting allows for TZ data now.

Fixes #703

cc @andrei-korshikov