### PR TITLE
TimeStamper now returns UTC timezone for custom format string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/25.2.0...HEAD)
 
+### Fixed
+- `structlog.processors.TimeStamper` now returns UTC timezone for custom format string.
 
 ## [25.2.0](https://github.com/hynek/structlog/compare/25.1.0...25.2.0) - 2025-03-11
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -553,12 +553,18 @@ def _make_stamper(
 
         return stamper_iso_local
 
-    def stamper_fmt(event_dict: EventDict) -> EventDict:
+    def stamper_fmt_local(event_dict: EventDict) -> EventDict:
         event_dict[key] = now().astimezone().strftime(fmt)
-
         return event_dict
 
-    return stamper_fmt
+    def stamper_fmt_utc(event_dict: EventDict) -> EventDict:
+        event_dict[key] = now().strftime(fmt)
+        return event_dict
+
+    if utc:
+        return stamper_fmt_utc
+
+    return stamper_fmt_local
 
 
 class MaybeTimeStamper:

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -415,6 +415,36 @@ class TestTimeStamper:
         assert "1980" == d["timestamp"]
 
     @freeze_time("1980-03-25 16:00:00")
+    def test_inserts_formatted_utc(self):
+        """
+        The fmt string in UTC timezone works.
+
+        The exact hours calculated here maybe incorrect because of freezegun bugs:
+        https://github.com/spulec/freezegun/issues/348
+        https://github.com/spulec/freezegun/issues/494
+        """
+
+        ts = TimeStamper(fmt="%Y-%m-%d %H:%M:%S %Z")
+        d = ts(None, None, {})
+
+        assert "1980-03-25 16:00:00 UTC" == d["timestamp"]
+
+    @freeze_time("1980-03-25 16:00:00")
+    def test_inserts_formatted_local(self):
+        """
+        The fmt string in local timezone works.
+
+        The exact hours calculated here maybe incorrect because of freezegun bugs:
+        https://github.com/spulec/freezegun/issues/348
+        https://github.com/spulec/freezegun/issues/494
+        """
+        local_tz = datetime.datetime.now().astimezone().tzname()
+        ts = TimeStamper(fmt="%Y-%m-%d %H:%M:%S %Z", utc=False)
+        d = ts(None, None, {})
+
+        assert f"1980-03-25 16:00:00 {local_tz}" == d["timestamp"]
+
+    @freeze_time("1980-03-25 16:00:00")
     def test_tz_aware(self):
         """
         The timestamp that is used for formatting is timezone-aware.


### PR DESCRIPTION
# Summary

This change reverts the ability to display a UTC timestamp with a custom strftime format string in `TimeStamper`. Before the change local time zone was used regardless of `utc=True` flag for TimeStamper. Output for `utc=False` is not changed and timezone is correctly displayed with `%z` and `%Z`. 

```python
from structlog.processors import TimeStamper
ts = TimeStamper(fmt="%Y-%m-%d %H:%M:%S %z %Z")
print(ts(None, None, {}))

# BEFORE
{'timestamp': '2025-03-18 10:24:40 +0100 CET'}
# AFTER
{'timestamp': '2025-03-18 09:23:36 +0000 UTC'}
``` 

Due to limitations in freezegun tests don't simulate execution is different timezones. Maybe a switch to [time-machine](https://pypi.org/project/time-machine/) can fix that. 

Feel free to remove comments and descriptions in changelog.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
