### PR TITLE
fix ExceptionPrettyPrinter custom formatter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#723](https://github.com/hynek/structlog/pull/723)
 
 ### Fixed
-- `structlog.processors.ExceptionPrettyPrinter` now uses *exception_formatter* instead of the default formatter if passed.
+
+- `structlog.processors.ExceptionPrettyPrinter` now respects the *exception_formatter* arguments instead of always using the default formatter.
 
 
 ## [25.3.0](https://github.com/hynek/structlog/compare/25.2.0...25.3.0) - 2025-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - Support for Python 3.14 and Python 3.13.4.
   [#723](https://github.com/hynek/structlog/pull/723)
 
+### Fixed
+- `structlog.processors.ExceptionPrettyPrinter` now uses *exception_formatter* instead of the default formatter if passed.
+
 
 ## [25.3.0](https://github.com/hynek/structlog/compare/25.2.0...25.3.0) - 2025-04-25
 

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -36,7 +36,7 @@ from structlog.processors import (
     format_exc_info,
 )
 from structlog.stdlib import ProcessorFormatter
-from structlog.typing import EventDict
+from structlog.typing import EventDict, ExcInfo
 
 from ..additional_frame import additional_frame
 
@@ -124,6 +124,26 @@ class TestExceptionPrettyPrinter:
 
         assert "test_prints_exception" in out
         assert "raise ValueError" in out
+
+    def test_uses_exception_formatter(self, sio):
+        """
+        If an `exception_formatter` is passed, use that to render the
+        exception rather than the default.
+        """
+
+        def formatter(exc_info: ExcInfo) -> str:
+            return f"error: {exc_info}"
+
+        epp = ExceptionPrettyPrinter(file=sio, exception_formatter=formatter)
+        try:
+            raise ValueError
+        except ValueError as e:
+            epp(None, None, {"exc_info": True})
+            formatted = formatter(e)
+
+        out = sio.getvalue()
+
+        assert formatted in out
 
     def test_removes_exception_after_printing(self, sio):
         """


### PR DESCRIPTION
# Summary

`structlog.processors.ExceptionPrettyPrinter` accepts an *exception_formatter* argument just like `structlog.processors.ExceptionRenderer` does, but it now actually uses the passed function instead of the default.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
