### PR TITLE
fix RecursionError when logging re-raised Exception from an ExceptionGroup #726

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   This works similarly to what Rich v14.0.0 does.
   [#720](https://github.com/hynek/structlog/pull/720)
 
+### Fixed
+- `structlog.tracebacks` Exceptions can now be re-raised from within an ExceptionGroup..
 
 ### Fixed
 

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -333,6 +333,11 @@ def extract(
             continue
 
         cause = exc_value.__context__
+        if sys.version_info >= (3, 11) and isinstance(
+            cause,
+            (BaseExceptionGroup, ExceptionGroup),  # noqa: F821
+        ):
+            break
         if (
             cause
             and cause.__traceback__

--- a/tests/test_tracebacks.py
+++ b/tests/test_tracebacks.py
@@ -1071,3 +1071,23 @@ class TestLogException:
         logger.exception("onoes")
 
         assert [{"event": "onoes", "log_level": "error"}] == cap_logs.entries
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="Requires Python 3.11 or higher"
+)
+def test_reraise_error_from_exception_group() -> None:
+    """
+    Test the behavior when re-throwing exceptions from ExceptionGroup,
+    especially whether it will cause recursive errors when used with the logger.
+    """
+    try:
+        try:
+            raise ExceptionGroup(  # noqa: F821
+                "Some error occurred",
+                [ValueError("value error")],
+            )
+        except ExceptionGroup as e:  # noqa: F821
+            raise e.exceptions[0]  # noqa: B904
+    except Exception as e:
+        tracebacks.extract(type(e), e, e.__traceback__)


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
Fixed a RecursionError when logging re-raised exceptions from an ExceptionGroup in Python 3.11 and above (#726). The fix adds a version check and detects when the exception cause is an ExceptionGroup, preventing further recursive traversal of the exception chain, which previously led to infinite recursion.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [ ] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
