### PR TITLE
Handle exception cycles

### DIFF
--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -239,8 +239,13 @@ def extract(
 
     stacks: list[Stack] = []
     is_cause = False
+    seen: set[int] = set()
 
     while True:
+        if id(exc_value) in seen:
+            break
+        seen.add(id(exc_value))
+
         stack = Stack(
             exc_type=safe_str(exc_type.__name__),
             exc_value=safe_str(exc_value),


### PR DESCRIPTION
When extracting frames for dict tracebacks, it's possible for exception cause chains to have cycles if a user calls `raise e from <something in its chain>`. Tracking the seen IDs would let the traceback break early in this case.

Thanks for maintaining a great library!