### PR TITLE
refactor: extract styles configuration to separate method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -76,7 +76,7 @@ API Reference
 .. automodule:: structlog.dev
 
 .. autoclass:: ConsoleRenderer
-   :members: get_default_level_styles
+   :members: get_default_level_styles, get_default_column_styles
 
 .. autoclass:: Column
 .. autoclass:: ColumnFormatter(typing.Protocol)

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -630,7 +630,7 @@ class ConsoleRenderer:
             return
 
         # Create default columns configuration.
-        styles = self.configure_styles(colors, force_colors)
+        styles = self.get_default_column_styles(colors, force_colors)
 
         self._styles = styles
 
@@ -698,7 +698,7 @@ class ConsoleRenderer:
         ]
 
     @classmethod
-    def configure_styles(
+    def get_default_column_styles(
         cls, colors: bool = _has_colors, force_colors: bool = False
     ) -> type[_Styles]:
         """


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
Extract the styles configuration logic from ConsoleRenderer.init into a dedicated configure_styles class method. This improves code readability and makes the styles setup logic reusable and testable.

- Move colorama initialization and styles selection to configure_styles()
- Add comprehensive docstring with args, returns, and raises sections
- Remove noqa comment as method complexity is now reduced
- Maintain existing behavior for colors and force_colors parameters

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
