### PR TITLE
MaybeTimeStamper: Fix custom keys always being overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.dev.rich_traceback()` now throws a more helpful error when Rich is missing.
   [#735](https://github.com/hynek/structlog/pull/735)
 
+### Fixed
+
+- `structlog.processors.MaybeTimeStamper` now respects the *key* argument when determining whether to overwrite the timestamp field.
+  [#747](https://github.com/hynek/structlog/pull/747)
+
 
 ## [25.4.0](https://github.com/hynek/structlog/compare/25.3.0...25.4.0) - 2025-06-02
 

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -592,7 +592,7 @@ class MaybeTimeStamper:
     def __call__(
         self, logger: WrappedLogger, name: str, event_dict: EventDict
     ) -> EventDict:
-        if "timestamp" not in event_dict:
+        if self.stamper.key not in event_dict:
             return self.stamper(logger, name, event_dict)
 
         return event_dict

--- a/tests/processors/test_renderers.py
+++ b/tests/processors/test_renderers.py
@@ -511,6 +511,14 @@ class TestMaybeTimeStamper:
 
         assert {"timestamp": 42} == mts(None, None, {"timestamp": 42})
 
+    def test_overwrite_custom_key(self):
+        """
+        If there is a timestamp with a custom key, leave it.
+        """
+        mts = MaybeTimeStamper(key="timestamp2")
+
+        assert {"timestamp2": 42} == mts(None, None, {"timestamp2": 42})
+
     def test_none(self):
         """
         If there is no timestamp, add one.


### PR DESCRIPTION
# Summary

Previously, the conditional always checked specifically for `timestamp`, which caused `MaybeTimeStamper` to always behave like `TimeStamper` when a custom key is used.

# Pull Request Check List

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.