### PR TITLE
feat: EventRenamer handle event=None

### DIFF
--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -960,7 +960,7 @@ class EventRenamer:
     def __call__(
         self, logger: logging.Logger, name: str, event_dict: EventDict
     ) -> EventDict:
-        event = event_dict.pop("event")
+        event = event_dict.pop("event", None)
         event_dict[self.to] = event
 
         if self.replace_by is not None:


### PR DESCRIPTION
# Summary

Let `EventRenamer` defaults to `None` in case `event` key is missing.

## Long one (more context)

I'm new to python development in general. I am adding `structlog` to my `uvicorn` app, so that the logs are parseable by the logs processor. My current orgs setup expect `message` key, hence I am using `EventRenamer`. But when my logger get passed `None` or `[]` (empty array), it will break the logger.

## Other considerations and questions:

Maybe let `None` be passed as `event`?

In the `_base.py` `_process_event`, there's this if-clause.

```py
if event is not None:
    event_dict["event"] = event
```

I wonder why do this?

## Other approach

I've added new custom processors like this:

```py
def ensure_event_key(_, __, event_dict: EventDict) -> EventDict:
    if 'event' not in event_dict:
        event_dict['event'] = ''
    return event_dict
```

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

I haven't done anything more than just this small change. I would like to validate my understanding first.

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
