### PR TITLE
Restore _write and _flush in WriteLogger.__setstate__

### DIFF
--- a/src/structlog/_output.py
+++ b/src/structlog/_output.py
@@ -186,6 +186,8 @@ class WriteLogger:
         else:
             self._file = stderr
 
+        self._write = self._file.write
+        self._flush = self._file.flush
         self._lock = _get_lock_for_file(self._file)
 
     def __deepcopy__(self, memodict: dict[str, object]) -> WriteLogger:


### PR DESCRIPTION
`WriteLogger.__setstate__` restores `_file` and `_lock` but not `_write` and `_flush`. After unpickling, any log method raises `AttributeError`:

```python
import pickle
from structlog import WriteLogger

logger = pickle.loads(pickle.dumps(WriteLogger()))
logger.info("hello")
# AttributeError: 'WriteLogger' object has no attribute '_write'
```

`BytesLogger.__setstate__` already restores all four attributes correctly, and `WriteLogger.__deepcopy__` does too — this was just missed in `__setstate__`.

The fix adds the two missing assignments after restoring `_file`.
