### PR TITLE
Add consistent snake_case/camelCase aliases for is_enabled_for & getEffectiveLevel

### DIFF
--- a/src/structlog/_native.py
+++ b/src/structlog/_native.py
@@ -238,7 +238,9 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
 
     # Introspection
     meths["is_enabled_for"] = lambda self, level: level >= min_level
+    meths["isEnabledFor"] = meths["is_enabled_for"]
     meths["get_effective_level"] = lambda self: min_level
+    meths["getEffectiveLevel"] = meths["get_effective_level"]
 
     return type(
         f"BoundLoggerFilteringAt{LEVEL_TO_NAME.get(min_level, 'Notset').capitalize()}",

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -394,18 +394,30 @@ class BoundLogger(BoundLoggerBase):
         """
         self._logger.callHandlers(record)
 
+    def isEnabledFor(self, level: int) -> bool:
+        """
+        Calls :meth:`logging.Logger.isEnabledFor` with unmodified arguments.
+        """
+        return self._logger.isEnabledFor(level)
+
+    def is_enabled_for(self, level: int) -> bool:
+        """
+        Alias for :meth:`isEnabledFor` for snake_case consistency.
+        """
+        return self.isEnabledFor(level)
+
+    def get_effective_level(self) -> int:
+        """
+        Alias for :meth:`getEffectiveLevel` for snake_case consistency.
+        """
+        return self.getEffectiveLevel()
+
     def getEffectiveLevel(self) -> int:
         """
         Calls :meth:`logging.Logger.getEffectiveLevel` with unmodified
         arguments.
         """
         return self._logger.getEffectiveLevel()
-
-    def isEnabledFor(self, level: int) -> bool:
-        """
-        Calls :meth:`logging.Logger.isEnabledFor` with unmodified arguments.
-        """
-        return self._logger.isEnabledFor(level)
 
     def getChild(self, suffix: str) -> logging.Logger:
         """

--- a/src/structlog/typing.py
+++ b/src/structlog/typing.py
@@ -198,11 +198,25 @@ class FilteringBoundLogger(BindableLogger, Protocol):
         .. versionadded:: 25.1.0
         """
 
+    def isEnabledFor(self, level: int) -> bool:
+        """
+        Alias for :meth:`is_enabled_for`.
+
+        .. versionadded:: 25.2.0
+        """
+
     def get_effective_level(self) -> int:
         """
         Return the effective level of the logger.
 
         .. versionadded:: 25.1.0
+        """
+
+    def getEffectiveLevel(self) -> int:
+        """
+        Alias for :meth:`get_effective_level`.
+
+        .. versionadded:: 25.2.0
         """
 
     def debug(self, event: str, *args: Any, **kw: Any) -> Any:


### PR DESCRIPTION
Fixes #779

## Problem
 and  have inconsistent method naming:
-  only has  /  (snake_case)
-  only has  /  (camelCase)

This causes  when the same code path can hit both classes depending on configuration.

## Solution
Add aliases so both classes support both naming conventions:

1. ****: Added  and  aliases to dynamically-created  classes
2. ****: Added  and  aliases to 
3. ****: Added both methods to the  protocol

## Testing
Verified both naming conventions work and return identical values on both  and .