### PR TITLE
Fix thread name CallsiteParameterAdder in async methods (issue #710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.WriteLogger` is usable after unpickling.
   [#787](https://github.com/hynek/structlog/pull/787)
 
+- `structlog.processors.CallsiteParameterAdder` now reports the calling thread's id and name for async log methods, instead of the thread from the executor pool that runs the underlying sync logger.
+  [#710](https://github.com/hynek/structlog/issues/710)
+  [#805](https://github.com/hynek/structlog/pull/805)
+
 
 ## [25.5.0](https://github.com/hynek/structlog/compare/25.4.0...25.5.0) - 2025-10-27
 

--- a/src/structlog/_native.py
+++ b/src/structlog/_native.py
@@ -13,6 +13,7 @@ import asyncio
 import collections
 import contextvars
 import sys
+import threading
 
 from collections.abc import Callable
 from typing import Any
@@ -28,7 +29,7 @@ from ._log_levels import (
     NOTSET,
     WARNING,
 )
-from .contextvars import _ASYNC_CALLING_STACK
+from .contextvars import _ASYNC_CALLING_STACK, _ASYNC_CALLING_THREAD
 from .typing import FilteringBoundLogger
 
 
@@ -60,6 +61,11 @@ async def aexception(
     if kw.get("exc_info", True) is True:
         kw["exc_info"] = sys.exc_info()
 
+    # Capture thread info before passing to executor
+    thread_id = threading.get_ident()
+    thread_name = threading.current_thread().name
+    thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
+
     scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
     ctx = contextvars.copy_context()
     try:
@@ -69,6 +75,7 @@ async def aexception(
         )
     finally:
         _ASYNC_CALLING_STACK.reset(scs_token)
+        _ASYNC_CALLING_THREAD.reset(thread_token)
 
     return runner
 
@@ -173,6 +180,11 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
             """
             event = _maybe_interpolate(event, args)
 
+            # Capture thread info before passing to executor
+            thread_id = threading.get_ident()
+            thread_name = threading.current_thread().name
+            thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
+
             scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
             ctx = contextvars.copy_context()
             try:
@@ -184,6 +196,7 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
                 )
             finally:
                 _ASYNC_CALLING_STACK.reset(scs_token)
+                _ASYNC_CALLING_THREAD.reset(thread_token)
 
         meth.__name__ = name
         ameth.__name__ = f"a{name}"
@@ -211,6 +224,11 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
         name = LEVEL_TO_NAME[level]
         event = _maybe_interpolate(event, args)
 
+        # Capture thread info before passing to executor
+        thread_id = threading.get_ident()
+        thread_name = threading.current_thread().name
+        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
+
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
         ctx = contextvars.copy_context()
         try:
@@ -222,6 +240,7 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
             )
         finally:
             _ASYNC_CALLING_STACK.reset(scs_token)
+            _ASYNC_CALLING_THREAD.reset(thread_token)
         return runner
 
     meths: dict[str, Callable[..., Any]] = {"log": log, "alog": alog}

--- a/src/structlog/_native.py
+++ b/src/structlog/_native.py
@@ -61,13 +61,13 @@ async def aexception(
     if kw.get("exc_info", True) is True:
         kw["exc_info"] = sys.exc_info()
 
-    # Capture thread info before passing to executor
-    thread_id = threading.get_ident()
-    thread_name = threading.current_thread().name
-    thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
-
+    # Capture thread-specific info before handing off to the executor.
+    thread_token = _ASYNC_CALLING_THREAD.set(
+        (threading.get_ident(), threading.current_thread().name)
+    )
     scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
     ctx = contextvars.copy_context()
+
     try:
         runner = await asyncio.get_running_loop().run_in_executor(
             None,
@@ -180,13 +180,13 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
             """
             event = _maybe_interpolate(event, args)
 
-            # Capture thread info before passing to executor
-            thread_id = threading.get_ident()
-            thread_name = threading.current_thread().name
-            thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
-
+            # Capture thread-specific info before handing off to the executor.
+            thread_token = _ASYNC_CALLING_THREAD.set(
+                (threading.get_ident(), threading.current_thread().name)
+            )
             scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
             ctx = contextvars.copy_context()
+
             try:
                 await asyncio.get_running_loop().run_in_executor(
                     None,
@@ -224,13 +224,13 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
         name = LEVEL_TO_NAME[level]
         event = _maybe_interpolate(event, args)
 
-        # Capture thread info before passing to executor
-        thread_id = threading.get_ident()
-        thread_name = threading.current_thread().name
-        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
-
+        # Capture thread-specific info before handing off to the executor.
+        thread_token = _ASYNC_CALLING_THREAD.set(
+            (threading.get_ident(), threading.current_thread().name)
+        )
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back)  # type: ignore[arg-type]
         ctx = contextvars.copy_context()
+
         try:
             runner = await asyncio.get_running_loop().run_in_executor(
                 None,
@@ -241,6 +241,7 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
         finally:
             _ASYNC_CALLING_STACK.reset(scs_token)
             _ASYNC_CALLING_THREAD.reset(thread_token)
+
         return runner
 
     meths: dict[str, Callable[..., Any]] = {"log": log, "alog": alog}

--- a/src/structlog/contextvars.py
+++ b/src/structlog/contextvars.py
@@ -38,6 +38,12 @@ _ASYNC_CALLING_STACK: contextvars.ContextVar[FrameType] = (
     contextvars.ContextVar("_ASYNC_CALLING_STACK")
 )
 
+# Stores thread info captured at async call time.
+# Value is a tuple of (thread_id: int, thread_name: str)
+_ASYNC_CALLING_THREAD: contextvars.ContextVar[tuple[int, str]] = (
+    contextvars.ContextVar("_ASYNC_CALLING_THREAD")
+)
+
 # For proper isolation, we have to use a dict of ContextVars instead of a
 # single ContextVar with a dict.
 # See https://github.com/hynek/structlog/pull/302 for details.

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -36,6 +36,7 @@ from ._frames import (
 )
 from ._log_levels import NAME_TO_LEVEL, add_log_level
 from ._utils import get_processname
+from .contextvars import _ASYNC_CALLING_THREAD
 from .tracebacks import ExceptionDictTransformer
 from .typing import (
     EventDict,
@@ -783,11 +784,21 @@ def _get_callsite_lineno(module: str, frame: FrameType) -> Any:
 
 
 def _get_callsite_thread(module: str, frame: FrameType) -> Any:
-    return threading.get_ident()
+    # Use captured thread info from async calls if available
+    try:
+        thread_info = _ASYNC_CALLING_THREAD.get()
+        return thread_info[0]
+    except LookupError:
+        return threading.get_ident()
 
 
 def _get_callsite_thread_name(module: str, frame: FrameType) -> Any:
-    return threading.current_thread().name
+    # Use captured thread info from async calls if available
+    try:
+        thread_info = _ASYNC_CALLING_THREAD.get()
+        return thread_info[1]
+    except LookupError:
+        return threading.current_thread().name
 
 
 def _get_callsite_process(module: str, frame: FrameType) -> Any:

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -784,21 +784,19 @@ def _get_callsite_lineno(module: str, frame: FrameType) -> Any:
 
 
 def _get_callsite_thread(module: str, frame: FrameType) -> Any:
-    # Use captured thread info from async calls if available
-    try:
-        thread_info = _ASYNC_CALLING_THREAD.get()
-        return thread_info[0]
-    except LookupError:
+    thread_info = _ASYNC_CALLING_THREAD.get(None)
+    if thread_info is None:
         return threading.get_ident()
+
+    return thread_info[0]
 
 
 def _get_callsite_thread_name(module: str, frame: FrameType) -> Any:
-    # Use captured thread info from async calls if available
-    try:
-        thread_info = _ASYNC_CALLING_THREAD.get()
-        return thread_info[1]
-    except LookupError:
+    thread_info = _ASYNC_CALLING_THREAD.get(None)
+    if thread_info is None:
         return threading.current_thread().name
+
+    return thread_info[1]
 
 
 def _get_callsite_process(module: str, frame: FrameType) -> Any:

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -34,7 +34,11 @@ from . import _config
 from ._base import BoundLoggerBase
 from ._frames import _find_first_app_frame_and_name, _format_stack
 from ._log_levels import LEVEL_TO_NAME, NAME_TO_LEVEL, add_log_level
-from .contextvars import _ASYNC_CALLING_STACK, _ASYNC_CALLING_THREAD, merge_contextvars
+from .contextvars import (
+    _ASYNC_CALLING_STACK,
+    _ASYNC_CALLING_THREAD,
+    merge_contextvars,
+)
 from .exceptions import DropEvent
 from .processors import StackInfoRenderer
 from .typing import (

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -16,6 +16,7 @@ import contextvars
 import functools
 import logging
 import sys
+import threading
 import warnings
 
 from collections.abc import Callable, Collection, Iterable, Sequence
@@ -33,7 +34,7 @@ from . import _config
 from ._base import BoundLoggerBase
 from ._frames import _find_first_app_frame_and_name, _format_stack
 from ._log_levels import LEVEL_TO_NAME, NAME_TO_LEVEL, add_log_level
-from .contextvars import _ASYNC_CALLING_STACK, merge_contextvars
+from .contextvars import _ASYNC_CALLING_STACK, _ASYNC_CALLING_THREAD, merge_contextvars
 from .exceptions import DropEvent
 from .processors import StackInfoRenderer
 from .typing import (
@@ -424,6 +425,11 @@ class BoundLogger(BoundLoggerBase):
         """
         Merge contextvars and log using the sync logger in a thread pool.
         """
+        # Capture thread info before passing to executor
+        thread_id = threading.get_ident()
+        thread_name = threading.current_thread().name
+        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
+
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back.f_back)  # type: ignore[union-attr, arg-type, unused-ignore]
         ctx = contextvars.copy_context()
 
@@ -434,6 +440,7 @@ class BoundLogger(BoundLoggerBase):
             )
         finally:
             _ASYNC_CALLING_STACK.reset(scs_token)
+            _ASYNC_CALLING_THREAD.reset(thread_token)
 
     async def adebug(self, event: str, *args: Any, **kw: Any) -> None:
         """
@@ -632,6 +639,11 @@ class AsyncBoundLogger:
         """
         Merge contextvars and log using the sync logger in a thread pool.
         """
+        # Capture thread info before passing to executor
+        thread_id = threading.get_ident()
+        thread_name = threading.current_thread().name
+        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
+
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back.f_back)  # type: ignore[union-attr, arg-type, unused-ignore]
         ctx = contextvars.copy_context()
 
@@ -642,6 +654,7 @@ class AsyncBoundLogger:
             )
         finally:
             _ASYNC_CALLING_STACK.reset(scs_token)
+            _ASYNC_CALLING_THREAD.reset(thread_token)
 
     async def debug(self, event: str, *args: Any, **kw: Any) -> None:
         await self._dispatch_to_sync(self.sync_bl.debug, event, args, kw)

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -429,11 +429,10 @@ class BoundLogger(BoundLoggerBase):
         """
         Merge contextvars and log using the sync logger in a thread pool.
         """
-        # Capture thread info before passing to executor
-        thread_id = threading.get_ident()
-        thread_name = threading.current_thread().name
-        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
-
+        # Capture thread-specific info before handing off to the executor.
+        thread_token = _ASYNC_CALLING_THREAD.set(
+            (threading.get_ident(), threading.current_thread().name)
+        )
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back.f_back)  # type: ignore[union-attr, arg-type, unused-ignore]
         ctx = contextvars.copy_context()
 
@@ -643,11 +642,10 @@ class AsyncBoundLogger:
         """
         Merge contextvars and log using the sync logger in a thread pool.
         """
-        # Capture thread info before passing to executor
-        thread_id = threading.get_ident()
-        thread_name = threading.current_thread().name
-        thread_token = _ASYNC_CALLING_THREAD.set((thread_id, thread_name))
-
+        # Capture thread-specific info before handing off to the executor.
+        thread_token = _ASYNC_CALLING_THREAD.set(
+            (threading.get_ident(), threading.current_thread().name)
+        )
         scs_token = _ASYNC_CALLING_STACK.set(sys._getframe().f_back.f_back)  # type: ignore[union-attr, arg-type, unused-ignore]
         ctx = contextvars.copy_context()
 

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -378,6 +378,7 @@ class TestCallsiteParameterAdder:
     async def test_async(self, wrapper_class, method_name) -> None:
         """
         Callsite information for async invocations are correct.
+        Thread information is now correctly captured before async bridge.
         """
         string_io = StringIO()
 
@@ -395,16 +396,61 @@ class TestCallsiteParameterAdder:
 
         logger = structlog.stdlib.get_logger()
 
+        # Capture thread info before async call
+        expected_thread = threading.get_ident()
+        expected_thread_name = threading.current_thread().name
+
         callsite_params = self.get_callsite_parameters()
         await getattr(logger, method_name)("baz")
         logger_params = json.loads(string_io.getvalue())
 
-        # These are different when running under async
+        # Thread info should now be correct (captured before async bridge)
+        assert logger_params["thread"] == expected_thread
+        assert logger_params["thread_name"] == expected_thread_name
+
+        # Remove thread info from comparison for remaining params
         for key in ["thread", "thread_name"]:
             callsite_params.pop(key)
             logger_params.pop(key)
 
         assert {"event": "baz", **callsite_params} == logger_params
+
+    @pytest.mark.asyncio
+    async def test_async_native_logger(self) -> None:
+        """
+        Callsite thread information for native async invocations is correct.
+        """
+        string_io = StringIO()
+
+        class StringIOLogger(structlog.PrintLogger):
+            def __init__(self):
+                super().__init__(file=string_io)
+
+        processor = CallsiteParameterAdder(
+            parameters=[
+                CallsiteParameter.THREAD,
+                CallsiteParameter.THREAD_NAME,
+            ]
+        )
+        structlog.configure(
+            processors=[processor, JSONRenderer()],
+            logger_factory=StringIOLogger,
+            wrapper_class=structlog._native.BoundLoggerFilteringAtInfo,
+            cache_logger_on_first_use=True,
+        )
+
+        logger = structlog.get_logger()
+
+        # Capture thread info before async call
+        expected_thread = threading.get_ident()
+        expected_thread_name = threading.current_thread().name
+
+        await logger.ainfo("test native async")
+        logger_params = json.loads(string_io.getvalue())
+
+        # Thread info should now be correct (captured before async bridge)
+        assert logger_params["thread"] == expected_thread
+        assert logger_params["thread_name"] == expected_thread_name
 
     def test_additional_ignores(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -36,6 +36,7 @@ from structlog.processors import (
     format_exc_info,
 )
 from structlog.stdlib import ProcessorFormatter
+from structlog.testing import CapturingLoggerFactory
 from structlog.typing import EventDict, ExcInfo
 
 from ..additional_frame import additional_frame
@@ -419,37 +420,32 @@ class TestCallsiteParameterAdder:
         """
         Callsite thread information for native async invocations is correct.
         """
-        string_io = StringIO()
-
-        class StringIOLogger(structlog.PrintLogger):
-            def __init__(self):
-                super().__init__(file=string_io)
-
-        processor = CallsiteParameterAdder(
-            parameters=[
-                CallsiteParameter.THREAD,
-                CallsiteParameter.THREAD_NAME,
-            ]
-        )
+        cf = CapturingLoggerFactory()
         structlog.configure(
-            processors=[processor, JSONRenderer()],
-            logger_factory=StringIOLogger,
+            processors=[
+                CallsiteParameterAdder(
+                    parameters=[
+                        CallsiteParameter.THREAD,
+                        CallsiteParameter.THREAD_NAME,
+                    ]
+                ),
+            ],
+            logger_factory=cf,
             wrapper_class=structlog._native.BoundLoggerFilteringAtInfo,
             cache_logger_on_first_use=True,
         )
 
         logger = structlog.get_logger()
 
-        # Capture thread info before async call
         expected_thread = threading.get_ident()
         expected_thread_name = threading.current_thread().name
 
         await logger.ainfo("test native async")
-        logger_params = json.loads(string_io.getvalue())
 
-        # Thread info should now be correct (captured before async bridge)
-        assert expected_thread == logger_params["thread"]
-        assert expected_thread_name == logger_params["thread_name"]
+        captured = cf.logger.calls[0].kwargs
+
+        assert expected_thread == captured["thread"]
+        assert expected_thread_name == captured["thread_name"]
 
     def test_additional_ignores(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """

--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -404,9 +404,8 @@ class TestCallsiteParameterAdder:
         await getattr(logger, method_name)("baz")
         logger_params = json.loads(string_io.getvalue())
 
-        # Thread info should now be correct (captured before async bridge)
-        assert logger_params["thread"] == expected_thread
-        assert logger_params["thread_name"] == expected_thread_name
+        assert expected_thread == logger_params["thread"]
+        assert expected_thread_name == logger_params["thread_name"]
 
         # Remove thread info from comparison for remaining params
         for key in ["thread", "thread_name"]:
@@ -449,8 +448,8 @@ class TestCallsiteParameterAdder:
         logger_params = json.loads(string_io.getvalue())
 
         # Thread info should now be correct (captured before async bridge)
-        assert logger_params["thread"] == expected_thread
-        assert logger_params["thread_name"] == expected_thread_name
+        assert expected_thread == logger_params["thread"]
+        assert expected_thread_name == logger_params["thread_name"]
 
     def test_additional_ignores(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """


### PR DESCRIPTION
## Problem

When using async logging methods (`.ainfo()`, etc.), the `CallsiteParameterAdder` processor was collecting thread information from the executor thread pool instead of the caller's thread. This caused `thread_name` to show 'asyncio_0' instead of the actual caller thread like 'MainThread'.

## Solution

This fix captures thread info (thread_id and thread_name) **before** passing control to the executor thread, storing it in a contextvar (`_ASYNC_CALLING_THREAD`) that is copied along with the calling stack frame. The processor then uses this captured thread info when available.

## Changes

1. **contextvars.py**: Added `_ASYNC_CALLING_THREAD` contextvar to store captured thread info
2. **_native.py**: Updated async methods to capture thread info before executor
3. **stdlib.py**: Updated async methods in both `BoundLogger` and `AsyncBoundLogger` to capture thread info
4. **processors.py**: Updated `_get_callsite_thread` and `_get_callsite_thread_name` to use captured info from contextvar
5. **tests**: Added tests to verify thread info is correctly captured in async context

## Testing

All tests pass:
- Native async tests
- Stdlib async tests  
- AsyncBoundLogger tests
- Existing processor tests

## Example Output

Before fix:
```
thread_name=asyncio_0  # Wrong - executor thread
```

After fix:
```
thread_name=MainThread  # Correct - caller's thread
```

Fixes #710