### PR TITLE
Expose remove_file_from_lock helper for WRITE_LOCKS cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/25.5.0...HEAD)
 
+### Added
+
+- `structlog.remove_file_from_lock()` to release the write lock that is implicitly registered for a file by `PrintLogger`, `WriteLogger`, and `BytesLogger`.
+  Useful when the underlying file is being closed.
+
+
 ### Removed
 
 - Python 3.8 and 3.9 support.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,6 +64,8 @@ API Reference
 
 .. autoclass:: BytesLoggerFactory
 
+.. autofunction:: remove_file_from_lock
+
 .. autoexception:: DropEvent
 
 .. autoclass:: BoundLoggerBase

--- a/src/structlog/__init__.py
+++ b/src/structlog/__init__.py
@@ -37,6 +37,7 @@ from structlog._output import (
     PrintLoggerFactory,
     WriteLogger,
     WriteLoggerFactory,
+    remove_file_from_lock,
 )
 from structlog.exceptions import DropEvent
 from structlog.testing import ReturnLogger, ReturnLoggerFactory
@@ -79,6 +80,7 @@ __all__ = [
     "is_configured",
     "make_filtering_bound_logger",
     "processors",
+    "remove_file_from_lock",
     "reset_defaults",
     "stdlib",
     "testing",

--- a/src/structlog/_output.py
+++ b/src/structlog/_output.py
@@ -30,8 +30,17 @@ def _get_lock_for_file(file: IO[Any]) -> threading.Lock:
     return lock
 
 
-def remove_file_from_lock(file: IO[Any]):
-    del WRITE_LOCKS[file]
+def remove_file_from_lock(file: IO[Any]) -> None:
+    """
+    Remove the write lock associated with *file* from the registry.
+
+    Useful when *file* is being closed and you want to release the lock that
+    was implicitly created for it by `PrintLogger`, `WriteLogger`, or
+    `BytesLogger`. A no-op if no lock is registered for *file*.
+
+    .. versionadded:: 26.1.0
+    """
+    WRITE_LOCKS.pop(file, None)
 
 
 class PrintLogger:

--- a/src/structlog/_output.py
+++ b/src/structlog/_output.py
@@ -30,6 +30,10 @@ def _get_lock_for_file(file: IO[Any]) -> threading.Lock:
     return lock
 
 
+def remove_file_from_lock(file: IO[Any]):
+    del WRITE_LOCKS[file]
+
+
 class PrintLogger:
     """
     Print events into a file.

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -17,6 +17,7 @@ from structlog import (
     PrintLoggerFactory,
     WriteLogger,
     WriteLoggerFactory,
+    remove_file_from_lock,
 )
 from structlog._output import WRITE_LOCKS, stderr, stdout
 
@@ -67,6 +68,17 @@ class TestLoggers:
         logger_cls(sio)
 
         assert sio in WRITE_LOCKS
+
+    def test_remove_file_from_lock(self, logger_cls, sio):
+        """
+        remove_file_from_lock removes the lock entry for the given file.
+        """
+        logger_cls(sio)
+        assert sio in WRITE_LOCKS
+
+        remove_file_from_lock(sio)
+
+        assert sio not in WRITE_LOCKS
 
     @pytest.mark.parametrize("method", stdlib_log_methods)
     def test_stdlib_methods_support(self, logger_cls, method, sio):

--- a/tests/typing/api.py
+++ b/tests/typing/api.py
@@ -9,6 +9,7 @@ Make sure our configuration examples actually pass the type checker.
 
 from __future__ import annotations
 
+import io
 import logging
 import logging.config
 
@@ -412,3 +413,7 @@ cr.event_key = "le event"
 
 cr.repr_native_str
 cr.repr_native_str = True
+
+_f = io.StringIO()
+structlog.PrintLogger(_f)
+structlog.remove_file_from_lock(_f)


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->

Hi, I'm an active user and contributor of Airflow. While investigating a memory leak in Airflow, I discovered that structlog's WRITE_LOCKS holds references to file descriptors created by the process, and these references prevent the associated loggers from being garbage collected even after they are no longer in use. I was able to confirm that the memory leak is resolved by importing WRITE_LOCKS and manually removing the references.

please reference the pr related: https://github.com/apache/airflow/pull/65121

As far as I can tell, there is currently no public interface for removing file references from WRITE_LOCKS. I don't think it's ideal for users to directly import and manipulate a variable from a private module. I've added a public interface that allows users to clean up WRITE_LOCKS references — I'd appreciate it if you could review it.

# Pull Request Check List

<!--
This list is our brown M&M test:
Ignoring -- or even deleting -- leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull requests is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [x] There's **tests** for all new and changed code.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->
