### PR TITLE
Use WeakKeyDictionary for WRITE_LOCKS to prevent file object leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ### Fixed
 
-- `WRITE_LOCKS` now uses a `weakref.WeakKeyDictionary` instead of a plain `dict`.
-  File objects used as keys are now released automatically when all application references are dropped, preventing a memory leak in long-running processes that open many log files (e.g., task executors that create a per-task `BytesLogger` or `WriteLogger`).
+- `structlog.BytesLogger`, `structlog.PrintLogger`, and `structlog.WriteLogger` now hold *weak* references to the files they use for output.
+  This prevents their leakage in long-running processes that open many logfiles, such as task executors that create a per-task `BytesLogger` or `WriteLogger`.
+  [#807](https://github.com/hynek/structlog/pull/807)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
   [#802](https://github.com/hynek/structlog/pull/802)
 
 
+### Fixed
+
+- `WRITE_LOCKS` now uses a `weakref.WeakKeyDictionary` instead of a plain `dict`.
+  File objects used as keys are now released automatically when all application references are dropped, preventing a memory leak in long-running processes that open many log files (e.g., task executors that create a per-task `BytesLogger` or `WriteLogger`).
+
+
 ### Changed
 
 - `structlog.dev.ConsoleRenderer` does not warn anymore when the `exception` key has a rendered value despite having a fancy formatter configured.

--- a/src/structlog/_output.py
+++ b/src/structlog/_output.py
@@ -12,13 +12,16 @@ from __future__ import annotations
 import copy
 import sys
 import threading
+import weakref
 
 from pickle import PicklingError
 from sys import stderr, stdout
 from typing import IO, Any, BinaryIO, TextIO
 
 
-WRITE_LOCKS: dict[IO[Any], threading.Lock] = {}
+WRITE_LOCKS: weakref.WeakKeyDictionary[IO[Any], threading.Lock] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def _get_lock_for_file(file: IO[Any]) -> threading.Lock:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -32,17 +32,19 @@ def test_write_locks_released_on_gc(logger_cls, mode, tmp_path):
     """
     WRITE_LOCKS entry is removed automatically when the file object is GC'd.
 
-    Closing the file is not enough — the entry persists until the file object
+    Closing the file is not enough -- the entry persists until the file object
     itself is collected.
     """
     gc.collect()
     size_before = len(WRITE_LOCKS)
     f = (tmp_path / "test.log").open(mode)
     logger = logger_cls(f)
+
     assert len(WRITE_LOCKS) == size_before + 1
 
     # close() alone does not remove the entry
     f.close()
+
     assert len(WRITE_LOCKS) == size_before + 1
 
     del logger, f

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,6 +4,7 @@
 # repository for complete details.
 
 import copy
+import gc
 import pickle
 
 from io import BytesIO, StringIO
@@ -21,6 +22,33 @@ from structlog import (
 from structlog._output import WRITE_LOCKS, stderr, stdout
 
 from .helpers import stdlib_log_methods
+
+
+@pytest.mark.parametrize(
+    ("logger_cls", "mode"),
+    [(PrintLogger, "w"), (WriteLogger, "w"), (BytesLogger, "wb")],
+)
+def test_write_locks_released_on_gc(logger_cls, mode, tmp_path):
+    """
+    WRITE_LOCKS entry is removed automatically when the file object is GC'd.
+
+    Closing the file is not enough — the entry persists until the file object
+    itself is collected.
+    """
+    gc.collect()
+    size_before = len(WRITE_LOCKS)
+    f = (tmp_path / "test.log").open(mode)
+    logger = logger_cls(f)
+    assert len(WRITE_LOCKS) == size_before + 1
+
+    # close() alone does not remove the entry
+    f.close()
+    assert len(WRITE_LOCKS) == size_before + 1
+
+    del logger, f
+    gc.collect()
+
+    assert len(WRITE_LOCKS) == size_before
 
 
 class TestLoggers:


### PR DESCRIPTION
File objects registered in WRITE_LOCKS were never released, causing a
memory leak in long-running processes that open many log files (e.g.,
task executors creating a per-task BytesLogger or WriteLogger).

WeakKeyDictionary stores keys as weak references, so entries expire
automatically when the last strong reference to a file object is
dropped — no manual cleanup needed.

Closes #806 (no need to expose it, we tidy it up correctly ourselves)

A test script to show that WeakKeyDict works:

```python
#!/usr/bin/env python
from __future__ import annotations

import gc
import tempfile
import weakref
from pathlib import Path

import structlog._output as _output


def _open_task_log(log_path: Path) -> tuple[object, weakref.ref]:
    """Open a log file, create a BytesLogger (registering it in WRITE_LOCKS).

    Returns the logger and a weakref to the underlying file so we can
    track whether the file object is GC'd after cleanup.

    Mirrors what Airflow's supervisor._configure_logging does per task.
    """
    import structlog

    fd = log_path.open("ab")
    ref = weakref.ref(fd)
    # BytesLogger.__init__ calls _get_lock_for_file(fd), inserting fd into
    # WRITE_LOCKS as a strong-reference key.
    _logger = structlog.BytesLogger(fd)
    fd.close()
    del fd
    return _logger, ref


def demonstrate_leak(n_tasks: int = 5) -> None:
    print(f"{'='*60}")
    print("PART 1 — current behaviour (plain dict)")
    print(f"{'='*60}")

    baseline = len(_output.WRITE_LOCKS)
    file_refs: list[weakref.ref] = []
    tmp_files: list[Path] = []

    for i in range(n_tasks):
        with tempfile.NamedTemporaryFile(suffix=f"-task{i}.log", delete=False) as t:
            log_path = Path(t.name)
        tmp_files.append(log_path)
        logger, ref = _open_task_log(log_path)
        file_refs.append(ref)
        del logger  # drop the last application-side reference

    gc.collect()

    added = len(_output.WRITE_LOCKS) - baseline
    still_alive = sum(1 for r in file_refs if r() is not None)

    print(f"Ran {n_tasks} tasks.")
    print(f"WRITE_LOCKS grew by {added} entries (expected {n_tasks}).")
    print(f"File objects still alive after close+del+gc: {still_alive}/{n_tasks}")
    print()
    if still_alive == n_tasks:
        print("  ✗  LEAK CONFIRMED: closed file objects kept alive by WRITE_LOCKS.")
    else:
        print("  (unexpected: some files freed — check for lingering references)")

    for p in tmp_files:
        p.unlink(missing_ok=True)
    print()



def demonstrate_fix(n_tasks: int = 5) -> None:
    print(f"{'='*60}")
    print("PART 2 — fixed behaviour (WeakKeyDictionary)")
    print(f"{'='*60}")

    # Patch WRITE_LOCKS.  _get_lock_for_file resolves WRITE_LOCKS as a
    # module-level name at call time, so replacing the module attribute is
    # sufficient — no need to monkey-patch the function itself.
    original = _output.WRITE_LOCKS
    weak_locks: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
    _output.WRITE_LOCKS = weak_locks  # type: ignore[assignment]

    try:
        file_refs: list[weakref.ref] = []
        tmp_files: list[Path] = []

        for i in range(n_tasks):
            with tempfile.NamedTemporaryFile(suffix=f"-task{i}.log", delete=False) as t:
                log_path = Path(t.name)
            tmp_files.append(log_path)
            logger, ref = _open_task_log(log_path)
            file_refs.append(ref)
            del logger

        gc.collect()

        locks_remaining = len(weak_locks)
        still_alive = sum(1 for r in file_refs if r() is not None)

        print(f"Ran {n_tasks} tasks.")
        print(f"WRITE_LOCKS entries remaining: {locks_remaining} (expected 0).")
        print(f"File objects still alive after close+del+gc: {still_alive}/{n_tasks}")
        print()
        if still_alive == 0 and locks_remaining == 0:
            print("  ✓  NO LEAK: file objects GC'd automatically, WRITE_LOCKS self-cleaned.")
        else:
            print("  (unexpected: some files survived — check for other references)")

        for p in tmp_files:
            p.unlink(missing_ok=True)

    finally:
        _output.WRITE_LOCKS = original

    print()

if __name__ == "__main__":
    demonstrate_leak()
    demonstrate_fix()

```


# Pull Request Check List

- [X] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [X] This pull requests is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [X] There's **tests** for all new and changed code.
- [X] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.rst` by hand.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [X] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
