### PR TITLE
stdlib: don't clear `LogRecord.args` before `ProcessorFormatter` processors run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 - `structlog.BytesLogger`, `structlog.PrintLogger`, and `structlog.WriteLogger` now hold *weak* references to the files they use for output.
   This prevents their leakage in long-running processes that open many logfiles, such as task executors that create a per-task `BytesLogger` or `WriteLogger`.
   [#807](https://github.com/hynek/structlog/pull/807)
+- `structlog.stdlib.ProcessorFormatter` no longer clears `LogRecord.args` before running its processor chain, so processors that inspect `event_dict["_record"].args` can see the original positional arguments.
+  `args` is still cleared before the record is handed to the underlying `logging.Formatter`.
+  [#771](https://github.com/hynek/structlog/issues/771)
 
 
 ### Changed

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -1141,8 +1141,6 @@ class ProcessorFormatter(logging.Formatter):
             if self.pass_foreign_args:
                 ed["positional_args"] = record.args
 
-            record.args = ()
-
             # Add stack-related attributes to the event dict
             if record.exc_info:
                 ed["exc_info"] = record.exc_info
@@ -1176,6 +1174,12 @@ class ProcessorFormatter(logging.Formatter):
             )
             ed = cast(str, ed)
 
+        # Clear args after processors have run so user processors can access
+        # ``record.args`` via ``_record``. We render our log records before
+        # sending them back to logging, so ``LogRecord.args`` must be cleared,
+        # otherwise stdlib's formatter would raise ``TypeError: not all
+        # arguments converted during string formatting``.
+        record.args = ()
         record.msg = ed
 
         return super().format(record)

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -1105,6 +1105,23 @@ class TestProcessorFormatter:
         assert "positional_args" in event_dict
         assert positional_args == event_dict["positional_args"]
 
+    def test_record_args_accessible_in_processor(self):
+        """
+        Processors can access ``record.args`` via ``_record``: args are not
+        cleared on the record before the formatter's processors run.
+        """
+        seen = []
+
+        def capture_args(_, __, event_dict):
+            seen.append(event_dict["_record"].args)
+            return event_dict
+
+        configure_logging((capture_args,))
+
+        logging.getLogger().info("test a=%s b=%s", "a", "b")
+
+        assert [("a", "b")] == seen
+
     def test_log_dict(self, capsys):
         """
         dicts can be logged with std library loggers.


### PR DESCRIPTION


# Summary

In the foreign branch of `ProcessorFormatter.format()`, `record.args = ()` was being assigned _before_ `foreign_pre_chain` and the main `processors` chain ran.
Processors that look at `event_dict["_record"].args` therefore always saw an empty tuple, even when stdlib was called with positional args like `logger.info("a=%s b=%s", "a", "b")`.

The clear is necessary: once `record.msg` is replaced with the rendered structlog string, leaving non-empty `record.args` makes `logging.Formatter.format()` raise `TypeError: not all arguments converted during string formatting`.
But it only needs to happen _after_ the processor chain.
The fix moves `record.args = ()` to right before `record.msg = ed` / `super().format(record)` and leaves a comment so a future refactor doesn't drop it again.

`test_clears_args` (the regression guard for the original `TypeError`) and `test_pass_foreign_args_true_sets_positional_args_key` still pass.
New `test_record_args_accessible_in_processor` reproduces #771 at the public API surface and asserts the foreign-pre-chain processor sees `record.args == ("a", "b")`.

Closes #771.

# Pull Request Check List

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull requests is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
- [x] There's **tests** for all new and changed code.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
  - No new APIs.
- [x] Updated **documentation** for changed code.
  - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - No new public symbols.
  - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
    - Behavior fix; public contract unchanged.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).