### PR TITLE
Add a recipe for customizing exc dict formatting

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -26,10 +26,12 @@ The most common use-cases are already covered by the following processors:
 
 : Uses {class}`structlog.tracebacks.ExceptionDictTransformer` to give you a structured and JSON-serializable `exception` key.
 
+
 ### Customizing Dict Tracebacks
 
 {class}`structlog.tracebacks.ExceptionDictTransformer` can be customized with a number of parameters.
 If these prove insufficient, see {ref}`Custom Filtering of Dict Tracebacks <custom-dict-tracebacks>`.
+
 
 ## Console rendering
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -26,6 +26,10 @@ The most common use-cases are already covered by the following processors:
 
 : Uses {class}`structlog.tracebacks.ExceptionDictTransformer` to give you a structured and JSON-serializable `exception` key.
 
+### Customizing Dict Tracebacks
+
+{class}`structlog.tracebacks.ExceptionDictTransformer` can be customized with a number of parameters.
+If these prove insufficient, see {ref}`Custom Filtering of Dict Tracebacks <custom-dict-tracebacks>`.
 
 ## Console rendering
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -141,6 +141,62 @@ These two methods and one attribute are all you need to write own *bound loggers
 [dry]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 
 
+(custom-dict-tracebacks)=
+
+## Custom Filtering of Dict Tracebacks
+
+Dict traceback printing via {class}`structlog.tracebacks.ExceptionDictTransformer` may expose values in logs which you do not want.
+For example, tokens and credentials are easily captured in locals and logged.
+
+As a simple control, you can set `show_locals=False`.
+For more extensive customization, subclass the transformer.
+
+{class}`ExceptionDictTransformer <structlog.tracebacks.ExceptionDictTransformer>`'s `__call__` is responsible for converting exception info into a list of dicts.
+Because this is only called during exception handling, it's an ideal point of control for potentially expensive filtering functionality.
+
+The following example customizes the transformer with a measure of string entropy, and redacts values in `locals` which exceed a threshold.
+
+```
+import math
+
+from structlog.tracebacks import ExceptionDictTransformer
+
+
+def is_high_entropy_string(data):
+    if not isinstance(data, str):
+        return False
+    charset = set(data)
+    entropy = 0
+    for c in charset:
+        p_x = data.count(c) / len(data)
+        entropy -= p_x * math.log2(p_x)
+    return entropy > 4.0
+
+
+def redact_locals(frame_locals):
+    redact_values = set()
+    for k, v in frame_locals.items():
+        if is_high_entropy_string(v):
+            redact_values.add(k)
+    return {
+        k: (v if k not in redact_values else "<REDACTED>")
+        for k, v in frame_locals.items()
+    }
+
+
+def redact_frames(exc_dict):
+    for frame in exc_dict["frames"]:
+        if "locals" in frame:
+            frame["locals"] = redact_locals(frame["locals"])
+    return exc_dict
+
+
+class RedactingExceptionDictTransformer(ExceptionDictTransformer):
+    def __call__(self, exc_info):
+        exceptions = super().__call__(exc_info)
+        return [redact_frames(exc) for exc in exceptions]
+```
+
 ## Passing context to worker threads
 
 Thread-local context data based on [context variables](contextvars.md) is -- as the name says -- local to the thread that binds it.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -154,32 +154,15 @@ For more extensive customization, subclass the transformer.
 {class}`ExceptionDictTransformer <structlog.tracebacks.ExceptionDictTransformer>`'s `__call__` is responsible for converting exception info into a list of dicts.
 Because this is only called during exception handling, it's an ideal point of control for potentially expensive filtering functionality.
 
-The following example customizes the transformer with a measure of string entropy, and redacts values in `locals` which exceed a threshold.
+The following example customizes the transformer to redact values in `locals` named `"token"` or `"password"`.
 
 ```
-import math
-
 from structlog.tracebacks import ExceptionDictTransformer
 
 
-def is_high_entropy_string(data):
-    if not isinstance(data, str):
-        return False
-    charset = set(data)
-    entropy = 0
-    for c in charset:
-        p_x = data.count(c) / len(data)
-        entropy -= p_x * math.log2(p_x)
-    return entropy > 4.0
-
-
 def redact_locals(frame_locals):
-    redact_values = set()
-    for k, v in frame_locals.items():
-        if is_high_entropy_string(v):
-            redact_values.add(k)
     return {
-        k: (v if k not in redact_values else "<REDACTED>")
+        k: (v if k not in ("token", "password") else "<REDACTED>")
         for k, v in frame_locals.items()
     }
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -183,6 +183,7 @@ class RedactingExceptionDictTransformer(ExceptionDictTransformer):
 Please remember that values may appear elsewhere in the dict traceback, for example in an exception string.
 If you remove data from `locals`, that does not guarantee that it is removed entirely from the log.
 
+
 ## Passing context to worker threads
 
 Thread-local context data based on [context variables](contextvars.md) is -- as the name says -- local to the thread that binds it.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -180,6 +180,9 @@ class RedactingExceptionDictTransformer(ExceptionDictTransformer):
         return [redact_frames(exc) for exc in exceptions]
 ```
 
+Please remember that values may appear elsewhere in the dict traceback, for example in an exception string.
+If you remove data from `locals`, that does not guarantee that it is removed entirely from the log.
+
 ## Passing context to worker threads
 
 Thread-local context data based on [context variables](contextvars.md) is -- as the name says -- local to the thread that binds it.


### PR DESCRIPTION
A new recipe titled "Custom Filtering of Dict Tracebacks" shows how to
subclass an ExceptionDictTransformer, dig around in the chain of
exceptions, sift through "locals", and make in-place modifications.

As a good demo of the sort of expensive function you might want to tie
to such operations, the example defines "high entropy strings" as
anything with a Shannon Entropy > 4.0 (which is arbitrary but somewhat
low).

In the `exceptions` documentation, a link is provided to this example
along with a direct indication that users should start by looking at the
parameters for `ExceptionDictTransformer`, which covers most cases.

resolves #789, #715

---

The example given is what sprang to mind for me, but I'm happy to rewrite it in any way that seems suitable.
(e.g., we could replace entropy with some simple bogus check like `len(data) == 42`)

# Summary

Add a new Recipe doc which shows how you can deeply customize dict tracebacks.

# Pull Request Check List

_NB: many check-list items marked as "vacuously true", as this is a pure docs change._

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull requests is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [x] There's **tests** for all new and changed code.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
