### PR TITLE
Explicit attribute type annotations

### DIFF
--- a/src/structlog/_output.py
+++ b/src/structlog/_output.py
@@ -271,6 +271,8 @@ class BytesLogger:
 
     __slots__ = ("_file", "_flush", "_lock", "_write", "name")
 
+    name: str | None
+
     def __init__(
         self, file: BinaryIO | None = None, *, name: str | None = None
     ):

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -147,6 +147,8 @@ class LogfmtRenderer:
     .. versionadded:: 21.5.0
     """
 
+    bool_as_flag: bool
+
     def __init__(
         self,
         sort_keys: bool = False,
@@ -404,6 +406,8 @@ class ExceptionRenderer:
     .. versionadded:: 22.1.0
     """
 
+    format_exception: ExceptionTransformer
+
     def __init__(
         self,
         exception_formatter: ExceptionTransformer = _format_exception,
@@ -477,6 +481,10 @@ class TimeStamper:
     """
 
     __slots__ = ("_stamper", "fmt", "key", "utc")
+
+    fmt: str | None
+    utc: bool
+    key: str
 
     def __init__(
         self,
@@ -580,6 +588,8 @@ class MaybeTimeStamper:
 
     __slots__ = ("stamper",)
 
+    stamper: TimeStamper
+
     def __init__(
         self,
         fmt: str | None = None,
@@ -653,6 +663,8 @@ class ExceptionPrettyPrinter:
     .. versionchanged:: 25.4.0
        Fixed *exception_formatter* so that it overrides the default if set.
     """
+
+    format_exception: ExceptionTransformer
 
     def __init__(
         self,
@@ -970,6 +982,9 @@ class EventRenamer:
 
     See also the :ref:`rename-event` recipe.
     """
+
+    to: str
+    replace_by: str | None
 
     def __init__(self, to: str, replace_by: str | None = None):
         self.to = to

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -784,6 +784,8 @@ class PositionalArgumentsFormatter:
     removed from the event dict after formatting a message.
     """
 
+    remove_positional_args: bool
+
     def __init__(self, remove_positional_args: bool = True) -> None:
         self.remove_positional_args = remove_positional_args
 
@@ -1094,6 +1096,14 @@ class ProcessorFormatter(logging.Formatter):
     .. versionadded:: 23.3.0 *use_get_message*
     """
 
+    processors: Sequence[Processor]
+    foreign_pre_chain: Sequence[Processor] | None
+    keep_exc_info: bool
+    keep_stack_info: bool
+    logger: logging.Logger | None
+    pass_foreign_args: bool
+    use_get_message: bool
+
     def __init__(
         self,
         processor: Processor | None = None,
@@ -1117,7 +1127,6 @@ class ProcessorFormatter(logging.Formatter):
             )
             raise TypeError(msg)
 
-        self.processors: Sequence[Processor]
         if processor is not None:
             self.processors = (self.remove_processors_meta, processor)
         elif processors:

--- a/src/structlog/tracebacks.py
+++ b/src/structlog/tracebacks.py
@@ -424,6 +424,15 @@ class ExceptionDictTransformer:
        Handle exception groups.
     """
 
+    show_locals: bool
+    locals_max_length: int
+    locals_max_string: int
+    locals_hide_dunder: bool
+    locals_hide_sunder: bool
+    suppress: Sequence[str]
+    max_frames: int
+    use_rich: bool
+
     def __init__(
         self,
         *,
@@ -450,7 +459,7 @@ class ExceptionDictTransformer:
         self.locals_max_string = locals_max_string
         self.locals_hide_dunder = locals_hide_dunder
         self.locals_hide_sunder = locals_hide_sunder
-        self.suppress: Sequence[str] = []
+        self.suppress = []
         for suppress_entity in suppress:
             if not isinstance(suppress_entity, str):
                 if suppress_entity.__file__ is None:

--- a/src/structlog/twisted.py
+++ b/src/structlog/twisted.py
@@ -133,6 +133,8 @@ class ReprWrapper:
     Note the extra quotes in the unwrapped example.
     """
 
+    string: str
+
     def __init__(self, string: str) -> None:
         self.string = string
 


### PR DESCRIPTION
# Summary

Hi there,

I see that you're serious about static typing here; awesome!

When I ran `pyrefly coverage check`  on the codebase, I noticed some opportunities for improvements because the reported type coverage (on main) is 93.49% (or 95.23% if you only consider the public API with `--public-only`).
So I figured I might as well contribute, and well, here I am :shrug:.

This adds explicit type annotations for the instance attributes, so that there's no need anymore to hope that all type-checkers infer the same intended types for them.
With this, the type coverage increased by +3.2% for a grand total of 96.68% (or with +3.66% to 98.89% with `--public-only`) :tada:.
These attribute annotations can also be considered as a form of documentation, because now you can easily see what attributes a certain class has and what their types are, without having to find the `__init__` parse manually parse the logic in there.

# Pull Request Checklist

<!--
This list is our brown M&M test:
Ignoring -- or even deleting -- leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull request is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [ ] There's **tests** for all new and changed code.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->

---

No AI was used; not even a little bit :)

I'm not sure if this is something you thing is worth putting in the changelog, so let me know if I should.