### PR TITLE
100% type coverage

### DIFF
--- a/src/structlog/contextvars.py
+++ b/src/structlog/contextvars.py
@@ -24,15 +24,15 @@ import contextvars
 
 from collections.abc import Generator, Mapping
 from types import FrameType
-from typing import Any
+from typing import Any, Final
 
 import structlog
 
 from .typing import BindableLogger, EventDict, WrappedLogger
 
 
-STRUCTLOG_KEY_PREFIX = "structlog_"
-STRUCTLOG_KEY_PREFIX_LEN = len(STRUCTLOG_KEY_PREFIX)
+STRUCTLOG_KEY_PREFIX: Final = "structlog_"
+STRUCTLOG_KEY_PREFIX_LEN: Final = len(STRUCTLOG_KEY_PREFIX)
 
 _ASYNC_CALLING_STACK: contextvars.ContextVar[FrameType] = (
     contextvars.ContextVar("_ASYNC_CALLING_STACK")

--- a/src/structlog/dev.py
+++ b/src/structlog/dev.py
@@ -468,7 +468,7 @@ class RichTracebackFormatter:
 
 if rich is None:
 
-    def rich_traceback(*args, **kw):
+    def rich_traceback(sio: TextIO, exc_info: ExcInfo) -> None:
         raise ModuleNotFoundError(
             "RichTracebackFormatter requires Rich to be installed.",
             name="rich",

--- a/src/structlog/processors.py
+++ b/src/structlog/processors.py
@@ -24,6 +24,7 @@ from types import FrameType, TracebackType
 from typing import (
     Any,
     ClassVar,
+    Final,
     NamedTuple,
     TextIO,
     cast,
@@ -424,7 +425,7 @@ class ExceptionRenderer:
         return event_dict
 
 
-format_exc_info = ExceptionRenderer()
+format_exc_info: Final = ExceptionRenderer()
 """
 Replace an ``exc_info`` field with an ``exception`` string field using Python's
 built-in traceback formatting.
@@ -445,7 +446,7 @@ is analog to the one of the stdlib's logging.
     features.
 """
 
-dict_tracebacks = ExceptionRenderer(ExceptionDictTransformer())
+dict_tracebacks: Final = ExceptionRenderer(ExceptionDictTransformer())
 """
 Replace an ``exc_info`` field with an ``exception`` field containing structured
 tracebacks suitable for, e.g., JSON output.

--- a/src/structlog/threadlocal.py
+++ b/src/structlog/threadlocal.py
@@ -21,7 +21,7 @@ import uuid
 import warnings
 
 from collections.abc import Generator, Iterator
-from typing import Any, TypeVar
+from typing import Any, Final, TypeVar
 
 import structlog
 
@@ -44,7 +44,7 @@ def _determine_threadlocal() -> type[Any]:
     return GreenThreadLocal  # pragma: no cover
 
 
-ThreadLocal = _determine_threadlocal()
+ThreadLocal: Final[type] = _determine_threadlocal()
 
 
 def _deprecated() -> None:


### PR DESCRIPTION
# Summary

Following #825, this fills in the last couple of missing annotations, bringing the `structlog` public type coverage to a beautiful 100% :tada:

Before:

```console
$ pyrefly coverage check --public-only src/structlog
 WARN `structlog.contextvars.STRUCTLOG_KEY_PREFIX_LEN` is untyped [coverage-missing]
  --> src/structlog/contextvars.py:35:1
   |
35 | STRUCTLOG_KEY_PREFIX_LEN = len(STRUCTLOG_KEY_PREFIX)
   | ------------------------
   |
 WARN `structlog.dev.rich_traceback` is untyped [coverage-missing]
   --> src/structlog/dev.py:471:5
    |
471 | /     def rich_traceback(*args, **kw):
472 | |         raise ModuleNotFoundError(
473 | |             "RichTracebackFormatter requires Rich to be installed.",
474 | |             name="rich",
475 | |         )
    | |_________-
    |
 WARN `structlog.processors.format_exc_info` is untyped [coverage-missing]
   --> src/structlog/processors.py:427:1
    |
427 | format_exc_info = ExceptionRenderer()
    | ---------------
    |
 WARN `structlog.processors.dict_tracebacks` is untyped [coverage-missing]
   --> src/structlog/processors.py:448:1
    |
448 | dict_tracebacks = ExceptionRenderer(ExceptionDictTransformer())
    | ---------------
    |
 WARN `structlog.threadlocal.ThreadLocal` is untyped [coverage-missing]
  --> src/structlog/threadlocal.py:47:1
   |
47 | ThreadLocal = _determine_threadlocal()
   | -----------
   |
ERROR type coverage 98.89% (622 of 629 typable) is below the 100.00% threshold
```

After:

```console
$ pyrefly coverage check --public-only src/structlog
 INFO type coverage 100.00% (630 of 630 typable)
```

# Pull Request Checklist

<!--
This list is our brown M&M test:
Ignoring -- or even deleting -- leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull request is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [ ] There's **tests** for all new and changed code.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->

---

Again, no AI was used; it was way too much fun to do this myself, after all :)

Oh and if you want, I could (as follow-up) add a light-weight CI job or something to ensure that coverage stays at 100%?