### PR TITLE
Fix: prevent PositionalArgumentsFormatter from crashing on TypeError (#258)

### DIFF
--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -12,6 +12,7 @@ See also :doc:`structlog's standard library support <standard-library>`.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import contextvars
 import functools
 import logging
@@ -802,13 +803,8 @@ class PositionalArgumentsFormatter:
             if len(args) == 1 and isinstance(args[0], dict) and args[0]:
                 args = args[0]
 
-            try:
+            with contextlib.suppress(TypeError, ValueError):
                 event_dict["event"] %= args
-            except (TypeError, ValueError):
-                # If formatting fails (e.g. mismatched %s placeholders),
-                # gracefully leave the event unformatted instead of crashing
-                # the application. This mimics the stdlib logging behavior.
-                pass
 
         if self.remove_positional_args and args is not None:
             del event_dict["positional_args"]

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -802,7 +802,13 @@ class PositionalArgumentsFormatter:
             if len(args) == 1 and isinstance(args[0], dict) and args[0]:
                 args = args[0]
 
-            event_dict["event"] %= args
+            try:
+                event_dict["event"] %= args
+            except (TypeError, ValueError):
+                # If formatting fails (e.g. mismatched %s placeholders),
+                # gracefully leave the event unformatted instead of crashing
+                # the application. This mimics the stdlib logging behavior.
+                pass
 
         if self.remove_positional_args and args is not None:
             del event_dict["positional_args"]

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -518,8 +518,6 @@ class TestPositionalArgumentsFormatter:
 
         assert {} == formatter(None, None, {"positional_args": ()})
 
-
-
     def test_graceful_failure_on_formatting_error(self):
         """
         If positional arguments do not match the formatting placeholders
@@ -530,7 +528,7 @@ class TestPositionalArgumentsFormatter:
         Regression test for https://github.com/hynek/structlog/issues/258.
         """
         formatter = PositionalArgumentsFormatter()
-        
+
         # Mismatched placeholders (event has no %s but args are passed)
         event_dict = formatter(
             None,

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -519,6 +519,29 @@ class TestPositionalArgumentsFormatter:
         assert {} == formatter(None, None, {"positional_args": ()})
 
 
+
+    def test_graceful_failure_on_formatting_error(self):
+        """
+        If positional arguments do not match the formatting placeholders
+        in the event string, PositionalArgumentsFormatter should not crash
+        with a TypeError or ValueError. It should leave the event string
+        unformatted.
+
+        Regression test for https://github.com/hynek/structlog/issues/258.
+        """
+        formatter = PositionalArgumentsFormatter()
+        
+        # Mismatched placeholders (event has no %s but args are passed)
+        event_dict = formatter(
+            None,
+            None,
+            {"event": "Info message", "positional_args": ("x",)},
+        )
+
+        assert "Info message" == event_dict["event"]
+        assert "positional_args" not in event_dict
+
+
 class TestAddLogLevelNumber:
     @pytest.mark.parametrize(("level", "number"), NAME_TO_LEVEL.items())
     def test_log_level_number_added(self, level, number):


### PR DESCRIPTION
Fixes #258. 

## Problem
When using `structlog` with `PositionalArgumentsFormatter`, passing a positional argument that does not match a formatting placeholder in the event string (e.g., `log.warning('Info message', 'x')`) raises an uncaught `TypeError: not all arguments converted during string formatting`. This crashes the entire application.

## Root Cause
In `src/structlog/stdlib.py`, the formatter directly executes `event_dict["event"] %= args` without catching formatting exceptions. This differs from the Python standard library `logging` module, which gracefully catches `TypeError` and `ValueError` during formatting to ensure logging never crashes the host application.

## Solution
This PR wraps the `%=` formatting operation in a `try...except (TypeError, ValueError)` block. If formatting fails due to a user error (mismatched placeholders), the exception is caught and the event string is simply left unformatted. This mimics the fail-safe behavior of stdlib logging and ensures that bad log statements do not result in fatal runtime errors.

A regression test has been added to `tests/test_stdlib.py` to verify that the processor gracefully handles mismatched placeholders without raising an exception.