### PR TITLE
Convert parametrize argvalues to lists for pytest 10

### DIFF
--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -482,16 +482,18 @@ class TestCallsiteParameterAdder:
 
     @pytest.mark.parametrize(
         ("origin", "parameter_strings"),
-        itertools.product(
-            ["logging", "structlog"],
-            [
-                None,
-                *[{parameter} for parameter in parameter_strings],
-                set(),
-                parameter_strings,
-                {"pathname", "filename"},
-                {"module", "func_name"},
-            ],
+        list(
+            itertools.product(
+                ["logging", "structlog"],
+                [
+                    None,
+                    *[{parameter} for parameter in parameter_strings],
+                    set(),
+                    parameter_strings,
+                    {"pathname", "filename"},
+                    {"module", "func_name"},
+                ],
+            )
         ),
     )
     def test_processor(
@@ -542,17 +544,24 @@ class TestCallsiteParameterAdder:
 
     @pytest.mark.parametrize(
         ("setup", "origin", "parameter_strings"),
-        itertools.product(
-            ["common-without-pre", "common-with-pre", "shared", "everywhere"],
-            ["logging", "structlog"],
-            [
-                None,
-                *[{parameter} for parameter in parameter_strings],
-                set(),
-                parameter_strings,
-                {"pathname", "filename"},
-                {"module", "func_name"},
-            ],
+        list(
+            itertools.product(
+                [
+                    "common-without-pre",
+                    "common-with-pre",
+                    "shared",
+                    "everywhere",
+                ],
+                ["logging", "structlog"],
+                [
+                    None,
+                    *[{parameter} for parameter in parameter_strings],
+                    set(),
+                    parameter_strings,
+                    {"pathname", "filename"},
+                    {"module", "func_name"},
+                ],
+            )
         ),
     )
     def test_e2e(


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->

**What:**

Two warnings show up when running `python -Im pytest`. They're about a pytest 10 deprecation: iterators passed to `parametrize` won't be accepted anymore.

**How:**

Wrap the `itertools.product()` calls passed to `pytest.mark.parametrize()` in `list()`.

**Why:**

`product()` returns a one-shot iterator. pytest 9 accepts it but emits `PytestRemovedIn10Warning`, and pytest 10 will require a `Collection`.

Converting to a list or tuple is the fix documented by pytest:
https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators

Same 948 tests collected before and after, so the parametrization didn't change.

Most of the diff is re-indentation caused by the added `list()` wrapper. `git diff -w` shows the actual change is two lines per call site.

**Verification:**

Running `python -Im pytest` shows the two `PytestRemovedIn10Warning`s are gone, reducing the warning count from **2 to 0**.

I skipped the changelog since this only touches tests.

# Pull Request Checklist

<!--
This list is our brown M&M test:
Ignoring -- or even deleting -- leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull request is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [x] There's **tests** for all new and changed code.
- [x] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/typing_tests/api.py).
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->
