### PR TITLE
fix: PytestRemovedIn10Warning Passing a non-Collection iterable to parametrize is deprecated.

### DIFF
--- a/tests/processors/test_processors.py
+++ b/tests/processors/test_processors.py
@@ -482,16 +482,18 @@ class TestCallsiteParameterAdder:
 
     @pytest.mark.parametrize(
         ("origin", "parameter_strings"),
-        itertools.product(
-            ["logging", "structlog"],
-            [
-                None,
-                *[{parameter} for parameter in parameter_strings],
-                set(),
-                parameter_strings,
-                {"pathname", "filename"},
-                {"module", "func_name"},
-            ],
+        list(
+            itertools.product(
+                ["logging", "structlog"],
+                [
+                    None,
+                    *[{parameter} for parameter in parameter_strings],
+                    set(),
+                    parameter_strings,
+                    {"pathname", "filename"},
+                    {"module", "func_name"},
+                ],
+            )
         ),
     )
     def test_processor(
@@ -542,17 +544,24 @@ class TestCallsiteParameterAdder:
 
     @pytest.mark.parametrize(
         ("setup", "origin", "parameter_strings"),
-        itertools.product(
-            ["common-without-pre", "common-with-pre", "shared", "everywhere"],
-            ["logging", "structlog"],
-            [
-                None,
-                *[{parameter} for parameter in parameter_strings],
-                set(),
-                parameter_strings,
-                {"pathname", "filename"},
-                {"module", "func_name"},
-            ],
+        list(
+            itertools.product(
+                [
+                    "common-without-pre",
+                    "common-with-pre",
+                    "shared",
+                    "everywhere",
+                ],
+                ["logging", "structlog"],
+                [
+                    None,
+                    *[{parameter} for parameter in parameter_strings],
+                    set(),
+                    parameter_strings,
+                    {"pathname", "filename"},
+                    {"module", "func_name"},
+                ],
+            )
         ),
     )
     def test_e2e(


### PR DESCRIPTION

# Summary

Hello

In PR fix warnings in tests
<details>
<summary>terminal output</summary>
```
(structlog) ➜  structlog git:(main) ✗ tox -e py315-tests
...
...
...
====================================================================== warnings summary =======================================================================
.tox/py315-tests/lib/python3.15/site-packages/_pytest/python.py:124
  /Users/vyuroshchin/github_my/structlog/.tox/py315-tests/lib/python3.15/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/processors/test_processors.py::TestCallsiteParameterAdder::test_processor, argvalues type: product
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

.tox/py315-tests/lib/python3.15/site-packages/_pytest/python.py:124
  /Users/vyuroshchin/github_my/structlog/.tox/py315-tests/lib/python3.15/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/processors/test_processors.py::TestCallsiteParameterAdder::test_e2e, argvalues type: product
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 884 passed, 37 skipped, 2 warnings in 1.72s =```

</details>

This warnings from pytest
https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize

# Pull Request Checklist

<!--
This list is our brown M&M test:
Ignoring -- or even deleting -- leads to instant closing of this pull request.
The only exceptions are pure documentation fixes.

Please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

You may check boxes that don't apply to your pull request to indicate that there isn't anything left to do.
-->

- [x] I acknowledge this project's [**AI policy**](https://github.com/hynek/structlog/blob/main/.github/AI_POLICY.md).
- [x] This pull request is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [x] There's **tests** for all new and changed code.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/typing_tests/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 26.1.0, the next version is gonna be 26.2.0. If the next version is the first in the new year, it'll be 27.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
Given the ongoing AI slop wave we need to be strict about policies, but we're happy to help out fellow humans.
-->


P.S. 
Question about add CHANGELOG.md:
Do I need to add a line to the changelog? My changes affect only the tests and do not impact the main code in any way.