### PR TITLE
Drop event dict keys colliding with LogRecord attributes in render_to_log_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ You can find our backwards-compatibility policy [here](https://github.com/hynek/
 
 ## [Unreleased](https://github.com/hynek/structlog/compare/26.1.0...HEAD)
 
+### Fixed
+
+- `structlog.stdlib.render_to_log_kwargs()` and `structlog.stdlib.render_to_log_args_and_kwargs()` now drop event dict keys that collide with a `logging.LogRecord` attribute (for example `filename` or `module`) instead of crashing the standard library with `KeyError: "Attempt to overwrite '...' in LogRecord"`.
+  [#486](https://github.com/hynek/structlog/issues/486)
+
 
 ## [26.1.0](https://github.com/hynek/structlog/compare/25.5.0...26.1.0) - 2026-06-06
 

--- a/src/structlog/stdlib.py
+++ b/src/structlog/stdlib.py
@@ -883,6 +883,14 @@ _LOG_RECORD_KEYS = logging.LogRecord(
     "name", 0, "pathname", 0, "msg", (), None
 ).__dict__.keys()
 
+# `Logger.makeRecord` raises `KeyError` for an `extra` key already on the
+# `LogRecord`: `_LOG_RECORD_KEYS`, plus "message"/"asctime" added later by
+# `Formatter.format()`. An event field named "filename" would crash.
+_RESERVED_LOG_RECORD_KEYS = frozenset(_LOG_RECORD_KEYS) | {
+    "message",
+    "asctime",
+}
+
 
 class ExtraAdder:
     """
@@ -960,9 +968,17 @@ def render_to_log_args_and_kwargs(
     arguments, keyword arguments are extracted from the *event_dict* and the
     rest of the *event_dict* is added as ``extra``.
 
+    Keys that collide with an attribute `logging.LogRecord` already carries
+    (for example ``filename`` or ``module``) are dropped instead of being
+    added to ``extra``, because the standard library rejects them there with
+    a `KeyError` at the point of logging.
+
     This allows you to defer formatting to `logging`.
 
     .. versionadded:: 25.1.0
+    .. versionchanged:: 26.2.0
+       Keys colliding with `logging.LogRecord` attributes are now dropped
+       from ``extra`` instead of crashing the standard library.
     """
     args = (event_dict.pop("event"), *event_dict.pop("positional_args", ()))
 
@@ -971,6 +987,8 @@ def render_to_log_args_and_kwargs(
         for kwarg_name in LOG_KWARG_NAMES
         if kwarg_name in event_dict
     }
+    for key in event_dict.keys() & _RESERVED_LOG_RECORD_KEYS:
+        del event_dict[key]
     if event_dict:
         kwargs["extra"] = event_dict
 
@@ -989,6 +1007,11 @@ def render_to_log_kwargs(
     extracted from the *event_dict* and the rest of the *event_dict* is added as
     ``extra``.
 
+    Keys that collide with an attribute `logging.LogRecord` already carries
+    (for example ``filename`` or ``module``) are dropped instead of being
+    added to ``extra``, because the standard library rejects them there with
+    a `KeyError` at the point of logging.
+
     This allows you to defer formatting to `logging`.
 
     .. versionadded:: 17.1.0
@@ -997,16 +1020,18 @@ def render_to_log_kwargs(
        kwargs and not put into ``extra``.
     .. versionchanged:: 24.2.0
        ``stackLevel`` corrected to ``stacklevel``.
+    .. versionchanged:: 26.2.0
+       Keys colliding with `logging.LogRecord` attributes are now dropped
+       from ``extra`` instead of crashing the standard library.
     """
-    return {
-        "msg": event_dict.pop("event"),
-        "extra": event_dict,
-        **{
-            kw: event_dict.pop(kw)
-            for kw in LOG_KWARG_NAMES
-            if kw in event_dict
-        },
+    msg = event_dict.pop("event")
+    kwargs = {
+        kw: event_dict.pop(kw) for kw in LOG_KWARG_NAMES if kw in event_dict
     }
+    for key in event_dict.keys() & _RESERVED_LOG_RECORD_KEYS:
+        del event_dict[key]
+
+    return {"msg": msg, "extra": event_dict, **kwargs}
 
 
 class ProcessorFormatter(logging.Formatter):

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -870,6 +870,34 @@ class TestRenderToLogArgsAndKwargs:
             extra=expected_extra,
         )
 
+    def test_drops_keys_colliding_with_log_record_attributes(
+        self, stdlib_logger: logging.Logger, caplog: pytest.LogCaptureFixture
+    ):
+        """
+        A key that collides with an attribute `logging.LogRecord` already
+        carries (for example "filename") is dropped from `extra` instead of
+        being passed through, because the standard library raises `KeyError`
+        when it's asked to overwrite it while building the record.
+
+        Cf. https://github.com/hynek/structlog/issues/486
+        """
+        event_dict = {
+            "event": "message",
+            "filename": "not-a-real-file.py",
+            "keep": "this",
+        }
+
+        args, kwargs = render_to_log_args_and_kwargs(
+            stdlib_logger, "info", event_dict
+        )
+
+        assert {"extra": {"keep": "this"}} == kwargs
+
+        with caplog.at_level(logging.INFO):
+            stdlib_logger.info(*args, **kwargs)
+
+        assert "this" == caplog.records[0].keep
+
     def test_integration(
         self, stdlib_logger: logging.Logger, event_dict: dict[str, Any]
     ):
@@ -986,6 +1014,41 @@ class TestRenderToLogKwargs:
         mock_log.assert_called_once_with(
             logging.INFO, "message", (), **expected
         )
+
+    def test_drops_keys_colliding_with_log_record_attributes(
+        self, stdlib_logger, caplog: pytest.LogCaptureFixture
+    ):
+        """
+        A key that collides with an attribute `logging.LogRecord` already
+        carries (for example "filename") is dropped from `extra` instead of
+        being passed through, because the standard library raises `KeyError`
+        when it's asked to overwrite it while building the record.
+
+        "message" collides too: it isn't on a fresh `LogRecord`, but the
+        standard library still special-cases and rejects it.
+
+        Cf. https://github.com/hynek/structlog/issues/486
+        """
+        d = render_to_log_kwargs(
+            None,
+            None,
+            {
+                "event": "message",
+                "filename": "not-a-real-file.py",
+                "message": "duplicate-of-msg",
+                "keep": "this",
+            },
+        )
+
+        assert {
+            "msg": "message",
+            "extra": {"keep": "this"},
+        } == d
+
+        with caplog.at_level(logging.INFO):
+            stdlib_logger.info(**d)
+
+        assert "this" == caplog.records[0].keep
 
     def test_integration_special_kw(self, event_dict, stdlib_logger):
         """


### PR DESCRIPTION

## Problem

`structlog.stdlib.render_to_log_kwargs()` and
`structlog.stdlib.render_to_log_args_and_kwargs()` are documented, standard
processors for "rendering your log entries entirely within `logging`" (see
`docs/standard-library.md`, "Processors" section). Both build the `extra`
kwarg they hand to the standard library out of whatever event dict keys are
left after `event`, `positional_args`, and the `exc_info`/`stack_info`/
`stacklevel` trio have been extracted.

If a remaining key happens to share a name with an attribute that
`logging.LogRecord` already carries -- `filename`, `module`, `process`,
`args`, `name`, `message`, and so on are all plausible field names for
someone's structured business data -- the standard library's own
`Logger.makeRecord()` rejects the call outright:

```pycon
>>> import logging, structlog
>>> structlog.configure(
...     processors=[structlog.stdlib.render_to_log_kwargs],
...     logger_factory=structlog.stdlib.LoggerFactory(),
...     wrapper_class=structlog.stdlib.BoundLogger,
... )
>>> logging.basicConfig(level=logging.DEBUG)
>>> log = structlog.get_logger("test")
>>> log.debug("hello", filename="not-a-file.py")
Traceback (most recent call last):
  ...
  File ".../logging/__init__.py", line 1656, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'filename' in LogRecord"
```

No `ProcessorFormatter` involved -- this is the plain "defer formatting to
`logging`" configuration from the docs. The log call itself raises, taking
down whatever code path tried to log.

## Root cause

`src/structlog/stdlib.py`, `render_to_log_kwargs()` (around line 1001,
pre-fix) and `render_to_log_args_and_kwargs()` (around line 961, pre-fix):
after popping `event`/`positional_args`/`LOG_KWARG_NAMES`, both functions
put the *entire remaining* event dict under `extra` unconditionally. They
never check it against the names `logging.LogRecord` already reserves for
itself.

This is exactly the reverse of what `structlog.stdlib.ExtraAdder` already
does a few dozen lines above in the same file: `ExtraAdder` merges a
`LogRecord`'s *own* extra fields into an event dict, and it explicitly
filters out `_LOG_RECORD_KEYS` (a `LogRecord`'s standard attribute names) so
that record-internal fields do not leak in as noise. `render_to_log_kwargs`/
`render_to_log_args_and_kwargs` do the same round trip in the opposite
direction (event dict -> `extra` on a soon-to-be-built `LogRecord`) but had
no equivalent filter.

Two names collide that are not in a fresh `LogRecord.__dict__` at all:
`"message"` and `"asctime"`. `Logger.makeRecord()` special-cases both and
rejects them regardless, because `Formatter.format()` adds them later:

```python
if (key in ["message", "asctime"]) or (key in rv.__dict__):
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
```

## Issue and prior state

This is https://github.com/hynek/structlog/issues/486, open since the
report against a Gunicorn integration. The maintainer identified the same
root cause in the issue thread and proposed the same fix direction ("this
needs to be fixed in `render_to_log_kwargs` and
`render_to_log_args_and_kwargs` by not putting these fields under these
names into `extra`"), but the only change that shipped
(commit `5400612`, "docs/stdlib: add warning about ProcessorFormatter")
only documents a *different, narrower* footgun: not to combine
`render_to_log_kwargs`/`render_to_log_args_and_kwargs` with
`ProcessorFormatter` (a real but separate problem, since `ProcessorFormatter`
adds its own `extra={"_logger": ..., "_name": ...}` on top). It does not
touch the underlying collision, which reproduces with a plain, non-
`ProcessorFormatter` configuration as shown above.

## Fix

Reuse the existing `_LOG_RECORD_KEYS` constant (already computed from a
fresh `LogRecord` for `ExtraAdder`), extended with `"message"` and
`"asctime"` as `_RESERVED_LOG_RECORD_KEYS`. Both `render_to_log_kwargs()`
and `render_to_log_args_and_kwargs()` now delete any event dict key that
intersects with that set before handing the remainder to `logging` as
`extra`. Non-colliding data is passed through exactly as before.

This drops the colliding field's value rather than renaming or raising.
That mirrors `ExtraAdder`'s own established precedent for the reverse
direction in this same file, and it means the fix trades a crash for a
silent, best-effort log entry instead of no log entry (and a raised
exception) at all -- see "Flags" below for the alternative the maintainer's
wording also allows.
